### PR TITLE
Update sample code for PVA Auth fix

### DIFF
--- a/BuildYourOwnCanvasSamples/3.single-sign-on/index.html
+++ b/BuildYourOwnCanvasSamples/3.single-sign-on/index.html
@@ -193,8 +193,7 @@ async function fetchJSON(url, options = {}) {
 (async function main() {
 
     // Add your BOT ID below 
-    var BOT_ID = "<BOT ID>";
-    var theURL = "https://powerva.microsoft.com/api/botmanagement/v1/directline/directlinetoken?botId=" + BOT_ID;
+    var theURL = "<Token endpoint URL>"
 
 	var userId = clientApplication.account?.accountIdentifier != null ? 
 					("You-customized-prefix" + clientApplication.account.accountIdentifier).substr(0, 64) 

--- a/BuildYourOwnCanvasSamples/3.single-sign-on/index.html
+++ b/BuildYourOwnCanvasSamples/3.single-sign-on/index.html
@@ -193,7 +193,7 @@ async function fetchJSON(url, options = {}) {
 (async function main() {
 
     // Add your BOT ID below 
-    var theURL = "<Token endpoint URL>"
+    var theURL = "<Token endpoint URL>" // you can find the token URL via the mobile app channel configuration
 
 	var userId = clientApplication.account?.accountIdentifier != null ? 
 					("You-customized-prefix" + clientApplication.account.accountIdentifier).substr(0, 64) 


### PR DESCRIPTION
@Kaiqb In October 2022, Alex created a PR with a PVA Auth fix and spoke with Bas who said that instead of using the bot ID, users should use the token endpoint URL and update this code sample. 

However, in order for users to use the token endpoint URL, the sample code needs to be updated. Specifically, the following lines from the sample:

var BOT_ID = "<bot id>";
var theURL = "https://powerva.microsoft.com/api/botmanagement/v1/directline/directlinetoken?botId=" + BOT_ID

would become

var theURL = "<Token endpoint URL>"

Alex updated the images in the article (power-virtual-agents/preview/configure-web-sso.md) to direct users to do this, but he suggested it would be a better experience if the sample was updated. He asked if @pawant-ms can update this sample code?