### PR TITLE
RelayBot: Upgrade from .netcore2.1 to .net9.0

### DIFF
--- a/RelayBotSample/Program.cs
+++ b/RelayBotSample/Program.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.PowerVirtualAgents.Samples.RelayBotSample
 {
@@ -10,11 +10,14 @@ namespace Microsoft.PowerVirtualAgents.Samples.RelayBotSample
     {
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/RelayBotSample/README.md
+++ b/RelayBotSample/README.md
@@ -6,7 +6,7 @@ This bot has been created based on [Bot Framework](https://dev.botframework.com)
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 2.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 9.0
 
   ```bash
   # determine dotnet version

--- a/RelayBotSample/SampleBot.csproj
+++ b/RelayBotSample/SampleBot.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.23.0" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
   </ItemGroup>
 

--- a/RelayBotSample/Startup.cs
+++ b/RelayBotSample/Startup.cs
@@ -3,11 +3,11 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.PowerVirtualAgents.Samples.RelayBotSample.Bots;
 
 namespace Microsoft.PowerVirtualAgents.Samples.RelayBotSample
@@ -24,7 +24,7 @@ namespace Microsoft.PowerVirtualAgents.Samples.RelayBotSample
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddControllers();
 
             // Create the Bot Framework Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
@@ -44,7 +44,7 @@ namespace Microsoft.PowerVirtualAgents.Samples.RelayBotSample
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -55,10 +55,19 @@ namespace Microsoft.PowerVirtualAgents.Samples.RelayBotSample
                 app.UseHsts();
             }
 
+            // app.UseHttpsRedirection();
+
             app.UseDefaultFiles();
             app.UseStaticFiles();
 
-            app.UseMvc();
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
         }
     }
 }


### PR DESCRIPTION
This should be helpful for deployment to Azure web app service, which requires .NET 8.0 or 9.0 as of today, since .NET core 2.1 was deprecated long ago.