### PR TITLE
Fix: MCP search species sample: copy command run on windows as well

### DIFF
--- a/MCPSamples/search-species-resources-typescript/package.json
+++ b/MCPSamples/search-species-resources-typescript/package.json
@@ -6,7 +6,7 @@
   "main": "build/index.js",
   "scripts": {
     "build": "tsc && npm run copy-assets",
-    "copy-assets": "cp -r src/assets build/",
+    "copy-assets": "copyfiles -u 1 \"src/assets/**/*\" build/",
     "start": "node build/index.js",
     "dev": "npm run build && node build/index.js"
   },
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^20.0.0",
+    "copyfiles": "^2.4.1",
     "typescript": "^5.3.0"
   }
 }


### PR DESCRIPTION
fixed the copy-assets script, which used `cp` not available on windows. 
now uses `copyfiles` instead (platform independent)