### PR TITLE
Include Supervisory Orgs in Workday Topics for Direct Reports

### DIFF
--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/README.md
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/README.md
@@ -4,8 +4,105 @@ search_exclude: false
 ---
 # Workday Manager Scenarios
 
-Copilot Studio topics for manager self-service actions in Workday.
+Copilot Studio topics for manager self-service actions in Workday. Topics for a Workday Manager's direct reports must cover all of the supervisory organizations that a manager may have. This requires a list of "supervisory organization IDs" which is provided in the Workday Set User Context topic and backed by a separate SOAP template. 
+
+Modify the Workday Set User Context topic with the following:
+
+```
+    - kind: BeginDialog
+      id: aV1Wue
+      input:
+        binding:
+          parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
+          scenarioName: msdyn_HRWorkdayHCMEmployeeGetData
+
+      dialog: msdyn_copilotforemployeeselfserviceit.topic.WorkdaySystemGetCommonExecution
+      output:
+        binding:
+          errorResponse: Topic.errorResponse
+          isSuccess: Topic.isSuccess
+          workdayResponse: Topic.workdayResponse
+
+    - kind: ParseValue
+      id: 9dxmb5
+      variable: Topic.parsedWorkerData
+      valueType:
+        kind: Record
+        properties:
+          EmploymentData:
+            type:
+              kind: Table
+              properties:
+                Organization_Role_Data:
+                  type:
+                    kind: Record
+                    properties:
+                      Organization_Role:
+                        type:
+                          kind: Record
+                          properties:
+                            Organization_Role_Data:
+                              type:
+                                kind: Table
+                                properties:
+                                  Assignment_From: String
+                                  Effective_Date: String
+                                  Role_Assigner_Reference:
+                                    type:
+                                      kind: Record
+                                      properties:
+                                        @Descriptor: String
+                                        ID:
+                                          type:
+                                            kind: Table
+                                            properties:
+                                              @type: String
+                                              "#text": String
+
+                            Organization_Role_Reference:
+                              type:
+                                kind: Record
+                                properties:
+                                  @Descriptor: String
+                                  ID:
+                                    type:
+                                      kind: Table
+                                      properties:
+                                        @type: String
+                                        "#text": String
+
+      value: =Topic.workdayResponse
+
+    - kind: SetVariable
+      id: setVariable_VMzjYp
+      variable: Global.Manager_Supervisory_OrgIds
+      value: |-
+        =Concat(
+            ForAll(
+                First(
+                    Filter(
+                        Topic.parsedWorkerData.EmploymentData,
+                        Organization_Role_Data.Organization_Role.Organization_Role_Reference.'@Descriptor' = "Manager"
+                    )
+                ).Organization_Role_Data.Organization_Role.Organization_Role_Data,
+                First(
+                    Filter(
+                        Role_Assigner_Reference.ID,
+                        '@type' = "Organization_Reference_ID"
+                    )
+                ).'#text'
+            ),
+            Value,
+            ","
+        )
+```
+
+Add the the [msdyn_HRWorkdayHCMEmployeeGetData](./msdyn_HRWorkdayHCMEmployeeGetData) SOAP template to the ESS template configuration.
 
 | Folder | Description |
 | --- | --- |
 | [WorkdayGetManagerReporteesTimeInPosition/](./WorkdayGetManagerReporteesTimeInPosition/) | View reportees' time in position |
+|  [WorkdayManagersdirect-CompanyCode](./WorkdayManagersdirect-CompanyCode/) | View reportees' company code details   |
+| [WorkdayManagersdirect-CostCenter](./WorkdayManagersdirect-CostCenter/)  | View reportees' cost center details |
+| [WorkdayManagersdirect-Jobtaxanomy](./WorkdayManagersdirect-Jobtaxanomy/)  | View details on reportees' job title, position, and other classifications  |
+| [WorkdayManagerServiceAnniversary](./WorkdayManagerServiceAnniversary/)  | View details on reportees' upcoming anniversaries   |

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition/README.md
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition/README.md
@@ -5,7 +5,7 @@ search_exclude: false
 # Workday Get Manager Reportees Time In Position
 
 ## Overview
-This scenario enables managers to view their direct reports along with how long each employee has been in their current position. It retrieves team member information from Workday HCM and calculates the time in position for each reportee.
+This scenario enables managers to view their direct reports along with how long each employee has been in their current position. For each supervisory organization, it retrieves team member information from Workday HCM and calculates the time in position for each reportee. The columns displayed can be altered by updating the topic's Model Description section.
 
 ## Files
 
@@ -17,7 +17,7 @@ This scenario enables managers to view their direct reports along with how long 
 ## Prerequisites
 
 ### Global Variables Required
-- `Global.ESS_UserContext_ManagerOrganizationId` - The manager's organization ID in Workday (used to filter direct reports)
+- `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager (used to filter direct reports)
 
 ### Workday API
 - **Service**: Human_Resources
@@ -81,30 +81,27 @@ The XML template is optimized for performance by:
 1. **Import the Topic**: Import `topic.yaml` into your Copilot Studio agent
 2. **Add XML Template**: Upload `msdyn_GetManagerReportees.xml` to your Workday connector configuration
 3. **Configure Connection**: Ensure your Workday connector connection reference is properly set in the topic
-4. **Set Global Variable**: Make sure `Global.ESS_UserContext_ManagerOrganizationId` is populated (typically from user authentication context)
+4. **Set Global Variable**: Make sure `Global.Manager_Supervisory_OrgIds` is populated (typically from user context setup)
 
 ## Model Instructions
 
 The topic includes model instructions for the AI to:
 - Display results as a nested markdown list
 - Format Time in Position clearly
-- Show Name, Job Title, Time in Position, Start Date, and Status for each reportee
+- Show Name, Job Title, Time in Position and Status for each reportee
 - Sort or group results based on user's question context
 
 ## Example Output
 
 When a manager asks "Show me my team's time in position", the agent displays:
 
-```
-Here are your direct reports and their time in current position:
+# Team roles and time in position
+Here's a list of your team members and how long they've been in their positions. I pulled this from Workday, an HR platform your company uses.
 
-- **John Smith** - Senior Developer
-  - Time in Position: 2 years, 5 months, 12 days
-  - Position Start: 2022-07-15
-  - Status: Active
-
-- **Jane Doe** - Product Manager
-  - Time in Position: 1 year, 2 months, 3 days
-  - Position Start: 2023-10-20
-  - Status: Active
-```
+> | Name | Title   | Time in Position | Status |
+> | ------------- | ------------- | ------------- | ------------- |
+> | Jane Doe	| Sales Solution Consultant |	8 months 28 days |	Active
+> | John Smith	| Sales Solution Consultant |	7 months 5 days |	Active
+> | Jack Doe	| Sales Solution Consultant	| 7 months 28 days |	Active
+>
+> If you need more details about a specific team member’s role or tenure, just let me know!

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition/README.md
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition/README.md
@@ -17,7 +17,9 @@ This scenario enables managers to view their direct reports along with how long 
 ## Prerequisites
 
 ### Global Variables Required
-- `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager (used to filter direct reports)
+- Check the `ManagerScenarios` folder for more details on prerequisites.
+    - `msdyn_HRWorkdayHCMEmployeeGetData` - A SOAP template for retrieving the Workday supervisory organization IDs for a manager
+    - `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager
 
 ### Workday API
 - **Service**: Human_Resources

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition/topic.yaml
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition/topic.yaml
@@ -10,7 +10,7 @@ modelDescription: |-
   For info on all direct reports time in position: Display in Table
   Heading - "Team roles and time in position"
   Verbatim line after heading: "Here's a list of your team members and how long they've been in their positions. I pulled this from Workday, an HR platform your company uses."
-  Table columns: Name, Title, Time in Position
+  Table columns: Name, Title, Time in Position, Status
 
   Common Rules ALWAYS FOLLOW:
   - ALWAYS add large sized heading with sentence case
@@ -43,7 +43,7 @@ beginDialog:
           displayName: Redirect to Workday Get Common Execution
           input:
             binding:
-              parameters: ="{""params"":[{""key"":""{Manager_Org_ID}"",""value"":""" & Global.ESS_UserContext_ManagerOrganizationId & """}]}"
+              parameters: ="{""params"":[{""key"":""{Manager_Org_ID}"",""value"":""" & Topic.SupOrgId & """}]}"
               scenarioName: msdyn_GetManagerReportees
 
           dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition/topic.yaml
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition/topic.yaml
@@ -23,102 +23,135 @@ beginDialog:
   intent: {}
   actions:
     - kind: BeginDialog
-      id: jJpz3n
-      displayName: Redirect to Workday Get Common Execution
-      input:
-        binding:
-          parameters: ="{""params"":[{""key"":""{Manager_Org_ID}"",""value"":""" & Global.ESS_UserContext_ManagerOrganizationId & """}]}"
-          scenarioName: msdyn_GetManagerReportees
-
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
-      output:
-        binding:
-          errorResponse: Topic.errorResponse
-          isSuccess: Topic.isSuccess
-          workdayResponse: Topic.workdayResponse
-
-    - kind: ParseValue
-      id: aXVFNu
-      displayName: Parse value to a record
-      variable: Topic.workdayResponseRecord
-      valueType:
-        kind: Record
-        properties:
-          BusinessTitle:
-            type:
-              kind: Table
-              properties:
-                Value: String
-
-          EmployeeID:
-            type:
-              kind: Table
-              properties:
-                Value: String
-
-          HireDate:
-            type:
-              kind: Table
-              properties:
-                Value: String
-
-          JobProfile:
-            type:
-              kind: Table
-              properties:
-                Value: String
-
-          Location:
-            type:
-              kind: Table
-              properties:
-                Value: String
-
-          Name:
-            type:
-              kind: Table
-              properties:
-                Value: String
-
-          PositionStartDate:
-            type:
-              kind: Table
-              properties:
-                Value: String
-
-          Status:
-            type:
-              kind: Table
-              properties:
-                Value: String
-
-          WorkerType:
-            type:
-              kind: Table
-              properties:
-                Value: String
-
-      value: =Topic.workdayResponse
+      id: WmAHrc
+      displayName: Check manager criteria
+      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdayManagerCheck
 
     - kind: SetVariable
-      id: setVariable_ztXmui
-      displayName: Extract data to table
+      id: setVariable_OBjpUF
+      variable: Topic.workdayAllOrgResponseTable
+      value: =[]
+
+    - kind: Foreach
+      id: foreach_niaz95
+      items: =Split(Global.Manager_Supervisory_OrgIds, ",")
+      value: Topic.SupOrgId
+      index: init:Topic.LoopIndex1
+      actions:
+        - kind: BeginDialog
+          id: jJpz3n
+          displayName: Redirect to Workday Get Common Execution
+          input:
+            binding:
+              parameters: ="{""params"":[{""key"":""{Manager_Org_ID}"",""value"":""" & Global.ESS_UserContext_ManagerOrganizationId & """}]}"
+              scenarioName: msdyn_GetManagerReportees
+
+          dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+          output:
+            binding:
+              errorResponse: Topic.errorResponse
+              isSuccess: Topic.isSuccess
+              workdayResponse: Topic.workdayResponse
+
+        - kind: ParseValue
+          id: aXVFNu
+          displayName: Parse value to a record
+          variable: Topic.workdayResponseRecord
+          valueType:
+            kind: Record
+            properties:
+              BusinessTitle:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
+
+              EmployeeID:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
+
+              HireDate:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
+
+              JobProfile:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
+
+              Location:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
+
+              Name:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
+
+              PositionStartDate:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
+
+              Status:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
+
+              WorkerType:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
+
+          value: =Topic.workdayResponse
+
+        - kind: SetVariable
+          id: setVariable_ztXmui
+          displayName: Extract data to table
+          variable: Topic.workdayResponseTable
+          value: |-
+            =ForAll(
+                Sequence(CountRows(Topic.workdayResponseRecord.EmployeeID)),
+                {
+                    EmployeeID: Last(FirstN(Topic.workdayResponseRecord.EmployeeID, Value)).Value,
+                    Name: Last(FirstN(Topic.workdayResponseRecord.Name, Value)).Value,
+                    BusinessTitle: Last(FirstN(Topic.workdayResponseRecord.BusinessTitle, Value)).Value,
+                    WorkerType: Last(FirstN(Topic.workdayResponseRecord.WorkerType, Value)).Value,
+                    JobProfile: Last(FirstN(Topic.workdayResponseRecord.JobProfile, Value)).Value,
+                    Location: Last(FirstN(Topic.workdayResponseRecord.Location, Value)).Value,
+                    PositionStartDate: Last(FirstN(Topic.workdayResponseRecord.PositionStartDate, Value)).Value,
+                    HireDate: Last(FirstN(Topic.workdayResponseRecord.HireDate, Value)).Value,
+                    Status: If(Last(FirstN(Topic.workdayResponseRecord.Status, Value)).Value = "1", "Active", "Inactive")
+                }
+            )
+
+        - kind: Foreach
+          id: foreach_rows_in_org
+          items: =Topic.workdayResponseTable
+          value: Topic.employeeRow
+          actions:
+            - kind: EditTableV2
+              id: editTableV2_AddWorkerRow
+              itemsVariable: Topic.workdayAllOrgResponseTable
+              changeType:
+                kind: AddItemOperation
+                value: =Topic.employeeRow
+
+    - kind: SetVariable
+      id: setVariable_P41zFQ
       variable: Topic.workdayResponseTable
-      value: |-
-        =ForAll(
-            Sequence(CountRows(Topic.workdayResponseRecord.EmployeeID)),
-            {
-                EmployeeID: Last(FirstN(Topic.workdayResponseRecord.EmployeeID, Value)).Value,
-                Name: Last(FirstN(Topic.workdayResponseRecord.Name, Value)).Value,
-                BusinessTitle: Last(FirstN(Topic.workdayResponseRecord.BusinessTitle, Value)).Value,
-                WorkerType: Last(FirstN(Topic.workdayResponseRecord.WorkerType, Value)).Value,
-                JobProfile: Last(FirstN(Topic.workdayResponseRecord.JobProfile, Value)).Value,
-                Location: Last(FirstN(Topic.workdayResponseRecord.Location, Value)).Value,
-                PositionStartDate: Last(FirstN(Topic.workdayResponseRecord.PositionStartDate, Value)).Value,
-                HireDate: Last(FirstN(Topic.workdayResponseRecord.HireDate, Value)).Value,
-                Status: If(Last(FirstN(Topic.workdayResponseRecord.Status, Value)).Value = "1", "Active", "Inactive")
-            }
-        )
+      value: =Topic.workdayAllOrgResponseTable
 
     - kind: SetVariable
       id: setVariable_AddTimeInPosition

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagerServiceAnniversary/README.md
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagerServiceAnniversary/README.md
@@ -1,0 +1,62 @@
+---
+nav_exclude: true
+search_exclude: false
+---
+# Workday Get Manager Reportees Service Anniversaries
+## Overview
+For each of their supervisory organizations, this scenario enables managers to view their direct reports along with Service Anniversary details.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `topic.yaml` | Copilot Studio topic definition with trigger phrases and Power Fx logic |
+| `msdyn_HRWorkdayHCMManagerServiceAnniversary.xml` | XML template for Workday Get_Workers API call |
+
+## Prerequisites
+
+### Global Variables Required
+- `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager (used to filter direct reports)
+
+### Workday API
+- **Service**: Human_Resources
+- **Operation**: Get_Workers
+- **Version**: v41.0
+
+## Scenario Details
+
+### What It Does
+1. Retrieves all employees in all supervisory organizations for the manager (all direct reports).
+2. Extracts key employee information (Job Title, Business Title, etc.)
+3. Presents results in a formatted table
+
+### Trigger Phrases
+- When are the service anniversaries of all my directs?
+- What are the service anniversaries of my entire team?
+- Show me the service anniversaries of my reports?
+
+## Response Group Configuration
+
+The XML template is optimized for performance by:
+- **Including**: Reference, Personal Information, Employment Information
+- **Excluding**: Compensation, Benefits, Documents, Photos, and other unnecessary data
+
+## Setup Instructions
+
+1. **Import the Topic**: Import `topic.yaml` into your Copilot Studio agent
+2. **Add XML Template**: Upload `msdyn_HRWorkdayHCMManagerServiceAnniversary.xml` to your Workday connector configuration
+3. **Configure Connection**: Ensure your Workday connector connection reference is properly set in the topic
+4. **Set Global Variable**: Make sure `Global.Manager_Supervisory_OrgIds` is populated (typically from user context setup)
+
+## Example Output
+
+When a manager asks "Show me my team's service anniversaries", the agent displays:
+
+> Here’s a summary of your team’s upcoming service anniversaries:
+> 
+> | Employee Name | Hire Date    | Upcoming Service Anniversary | Upcoming Milestone |
+> | ------------- | ------------- | ------------- | ------------- |
+> | John Doe      | 	2025-07-01	|2026-07-01 |	1 year          |
+> | Jane Doe      |	2025-08-25	|2026-08-25	|   1 year          |
+> | John Smith    |	2025-08-01	| 2026-08-01 |  1 year          |
+

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagerServiceAnniversary/README.md
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagerServiceAnniversary/README.md
@@ -16,7 +16,9 @@ For each of their supervisory organizations, this scenario enables managers to v
 ## Prerequisites
 
 ### Global Variables Required
-- `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager (used to filter direct reports)
+- Check the `ManagerScenarios` folder for more details on prerequisites.
+    - `msdyn_HRWorkdayHCMEmployeeGetData` - A SOAP template for retrieving the Workday supervisory organization IDs for a manager
+    - `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager
 
 ### Workday API
 - **Service**: Human_Resources

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagerServiceAnniversary/topic.yaml
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagerServiceAnniversary/topic.yaml
@@ -56,67 +56,95 @@ beginDialog:
       variable: Topic.currentDate
       value: =Now()
 
-    - kind: BeginDialog
-      id: HZDypL
-      displayName: Redirect to Workday Get Common Execution
-      input:
-        binding:
-          parameters: ="{""params"":[{""key"":""{ManagerOrgId}"",""value"":""" & Global.ESS_UserContext_ManagerOrganizationId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
-          scenarioName: msdyn_HRWorkdayHCMManagerServiceAnniversary
+    - kind: SetVariable
+      id: setVariable_OBjpUF
+      variable: Topic.workdayAllOrgResponseTable
+      value: =[]
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
-      output:
-        binding:
-          errorResponse: Topic.errorResponse
-          isSuccess: Topic.isSuccess
-          workdayResponse: Topic.workdayResponse
+    - kind: Foreach
+      id: foreach_niaz95
+      items: =Split(Global.Manager_Supervisory_OrgIds, ",")
+      value: Topic.SupOrgId
+      index: init:Topic.LoopIndex1
+      actions:
+        - kind: BeginDialog
+          id: HZDypL
+          displayName: Redirect to Workday Get Common Execution
+          input:
+            binding:
+              parameters: ="{""params"":[{""key"":""{ManagerOrgId}"",""value"":""" & Topic.SupOrgId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
+              scenarioName: msdyn_HRWorkdayHCMManagerServiceAnniversary
 
-    - kind: ParseValue
-      id: Nh88X0
-      displayName: Parse Workday response
-      variable: Topic.parsedWorkdayResponse
-      valueType:
-        kind: Record
-        properties:
-          FirstName:
-            type:
-              kind: Table
-              properties:
-                Value: String
+          dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+          output:
+            binding:
+              errorResponse: Topic.errorResponse
+              isSuccess: Topic.isSuccess
+              workdayResponse: Topic.workdayResponse
 
-          HireDate:
-            type:
-              kind: Table
-              properties:
-                Value: String
+        - kind: ParseValue
+          id: Nh88X0
+          displayName: Parse Workday response
+          variable: Topic.parsedWorkdayResponse
+          valueType:
+            kind: Record
+            properties:
+              FirstName:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-          LastName:
-            type:
-              kind: Table
-              properties:
-                Value: String
+              HireDate:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-          WorkerID:
-            type:
-              kind: Table
-              properties:
-                Value: String
+              LastName:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-      value: =Topic.workdayResponse
+              WorkerID:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
+
+          value: =Topic.workdayResponse
+
+        - kind: SetVariable
+          id: setVariable_eJUuES
+          displayName: Build Workday response table
+          variable: Topic.workdayResponseTable
+          value: |-
+            =ForAll(
+                        Sequence(CountRows(Topic.parsedWorkdayResponse.WorkerID)),
+                        {
+                            FirstName: Last(FirstN(Topic.parsedWorkdayResponse.FirstName, Value)).Value,
+                            LastName: Last(FirstN(Topic.parsedWorkdayResponse.LastName, Value)).Value,
+                            HireDate: Last(FirstN(Topic.parsedWorkdayResponse.HireDate, Value)).Value
+                        }
+                    )
+
+        - kind: Foreach
+          id: foreach_rows_in_org
+          items: =Topic.workdayResponseTable
+          value: Topic.employeeRow
+          actions:
+            - kind: EditTableV2
+              id: editTableV2_AddWorkerRow
+              itemsVariable: Topic.workdayAllOrgResponseTable
+              changeType:
+                kind: AddItemOperation
+                value: =Topic.employeeRow
 
     - kind: SetVariable
-      id: setVariable_eJUuES
-      displayName: Build Workday response table
+      id: setVariable_P41zFQ
       variable: Topic.workdayResponseTable
-      value: |-
-        =ForAll(
-                    Sequence(CountRows(Topic.parsedWorkdayResponse.WorkerID)),
-                    {
-                        FirstName: Last(FirstN(Topic.parsedWorkdayResponse.FirstName, Value)).Value,
-                        LastName: Last(FirstN(Topic.parsedWorkdayResponse.LastName, Value)).Value,
-                        HireDate: Last(FirstN(Topic.parsedWorkdayResponse.HireDate, Value)).Value
-                    }
-                )
+      value: =Topic.workdayAllOrgResponseTable
 
     - kind: ConditionGroup
       id: conditionGroup_P6QlNE

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CompanyCode/README.md
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CompanyCode/README.md
@@ -1,0 +1,64 @@
+---
+nav_exclude: true
+search_exclude: false
+---
+# Workday Get Manager Reportees Company Codes
+
+## Overview
+This scenario enables managers to view their direct reports along with Company Code or Company Name details for each of their supervisory organizations.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `topic.yaml` | Copilot Studio topic definition with trigger phrases and Power Fx logic |
+| `msdyn_HRWorkdayHCMManagerDirectCompanyCode.xml` | XML template for Workday Get_Workers API call |
+
+## Prerequisites
+
+### Global Variables Required
+- `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager (used to filter direct reports)
+
+### Workday API
+- **Service**: Human_Resources
+- **Operation**: Get_Workers
+- **Version**: v41.0
+
+## Scenario Details
+
+### What It Does
+1. Retrieves all employees in all supervisory organizations for the manager (all direct reports).
+2. Extracts key employee information (Name, Company Code, Company Name, etc.)
+3. Presents results in a formatted table
+
+### Trigger Phrases
+- What is the company code of my direct reports?
+- Show my team's company code
+- What are the company codes for my reports? 
+- What company codes are mapped to my team members?
+
+## Response Group Configuration
+
+The XML template is optimized for performance by:
+- **Including**: Reference, Personal Information, Employment Information
+- **Excluding**: Compensation, Benefits, Documents, Photos, and other unnecessary data
+
+## Setup Instructions
+
+1. **Import the Topic**: Import `topic.yaml` into your Copilot Studio agent
+2. **Add XML Template**: Upload `msdyn_HRWorkdayHCMManagerDirectCompanyCode.xml` to your Workday connector configuration
+3. **Configure Connection**: Ensure your Workday connector connection reference is properly set in the topic
+4. **Set Global Variable**: Make sure `Global.Manager_Supervisory_OrgIds` is populated (typically from user context setup)
+
+## Example Output
+
+When a manager asks "Show me my team's company codes", the agent displays:
+
+> # Team company codes
+> Here’s the company code information for your team:
+> 
+> * John Smith: Company code is GMS USA (Global Modern Services, Inc. (USA))
+> * John Doe: Company code is GMS USA (Global Modern Services, Inc. (USA))
+> * Jane Smith: Company code is GMS USA (Global Modern Services, Inc. (USA))
+> 
+> If you need more details or want to see company codes for other teams, just let me know!

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CompanyCode/README.md
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CompanyCode/README.md
@@ -17,7 +17,9 @@ This scenario enables managers to view their direct reports along with Company C
 ## Prerequisites
 
 ### Global Variables Required
-- `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager (used to filter direct reports)
+- Check the `ManagerScenarios` folder for more details on prerequisites.
+    - `msdyn_HRWorkdayHCMEmployeeGetData` - A SOAP template for retrieving the Workday supervisory organization IDs for a manager
+    - `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager
 
 ### Workday API
 - **Service**: Human_Resources

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CompanyCode/msdyn_HRWorkdayHCMManagerDirectCompanyCode.xml
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CompanyCode/msdyn_HRWorkdayHCMManagerDirectCompanyCode.xml
@@ -1,5 +1,5 @@
 <workdayEntityConfigurationTemplate>
-	<scenario name="GetManagerDirectCompanyCode">
+	<scenario name="msdyn_HRWorkdayHCMManagerDirectCompanyCode">
 		<apiRequests>
 			<apiRequest>
 				<authType>User</authType>

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CompanyCode/topic.yaml
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CompanyCode/topic.yaml
@@ -35,74 +35,102 @@ beginDialog:
       displayName: Check manager status
       dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdayManagerCheck
 
-    - kind: BeginDialog
-      id: Gt044B
-      displayName: Redirect to Workday Get Common Execution
-      input:
-        binding:
-          parameters: ="{""params"":[{""key"":""{ManagerOrgId}"",""value"":""" & Global.ESS_UserContext_ManagerOrganizationId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
-          scenarioName: msdyn_HRWorkdayHCMManagerDirectCompanyCode
+    - kind: SetVariable
+      id: setVariable_OBjpUF
+      variable: Topic.workdayAllOrgResponseTable
+      value: =[]
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
-      output:
-        binding:
-          errorResponse: Topic.errorResponse
-          isSuccess: Topic.isSuccess
-          workdayResponse: Topic.workdayResponse
+    - kind: Foreach
+      id: foreach_niaz95
+      items: =Split(Global.Manager_Supervisory_OrgIds, ",")
+      value: Topic.SupOrgId
+      index: init:Topic.LoopIndex1
+      actions:
+        - kind: BeginDialog
+          id: Gt044B
+          displayName: Redirect to Workday Get Common Execution
+          input:
+            binding:
+              parameters: ="{""params"":[{""key"":""{ManagerOrgId}"",""value"":""" & Topic.SupOrgId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
+              scenarioName: msdyn_HRWorkdayHCMManagerDirectCompanyCode
 
-    - kind: ParseValue
-      id: aIxWzK
-      displayName: Parse value to a table
-      variable: Topic.WorkdayResponseRecord
-      valueType:
-        kind: Record
-        properties:
-          CompanyCode:
-            type:
-              kind: Table
-              properties:
-                Value: String
+          dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+          output:
+            binding:
+              errorResponse: Topic.errorResponse
+              isSuccess: Topic.isSuccess
+              workdayResponse: Topic.workdayResponse
 
-          CompanyName:
-            type:
-              kind: Table
-              properties:
-                Value: String
+        - kind: ParseValue
+          id: aIxWzK
+          displayName: Parse value to a table
+          variable: Topic.WorkdayResponseRecord
+          valueType:
+            kind: Record
+            properties:
+              CompanyCode:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-          FirstName:
-            type:
-              kind: Table
-              properties:
-                Value: String
+              CompanyName:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-          LastName:
-            type:
-              kind: Table
-              properties:
-                Value: String
+              FirstName:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-          WorkerID:
-            type:
-              kind: Table
-              properties:
-                Value: String
+              LastName:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-      value: =Topic.workdayResponse
+              WorkerID:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
+
+          value: =Topic.workdayResponse
+
+        - kind: SetVariable
+          id: HC2h7w
+          displayName: Merge all records in table
+          variable: Topic.workdayResponseTable
+          value: |-
+            =ForAll(
+                Sequence(CountRows(Topic.WorkdayResponseRecord.WorkerID)),
+                {
+                    FirstName: Last(FirstN(Topic.WorkdayResponseRecord.FirstName, Value)).Value,
+                    LastName: Last(FirstN(Topic.WorkdayResponseRecord.LastName, Value)).Value,
+                    CompanyCode: Last(FirstN(Topic.WorkdayResponseRecord.CompanyCode, Value)).Value,
+                    CompanyName: Last(FirstN(Topic.WorkdayResponseRecord.CompanyName, Value)).Value
+                }
+            )
+
+        - kind: Foreach
+          id: foreach_rows_in_org
+          items: =Topic.workdayResponseTable
+          value: Topic.employeeRow
+          actions:
+            - kind: EditTableV2
+              id: editTableV2_AddWorkerRow
+              itemsVariable: Topic.workdayAllOrgResponseTable
+              changeType:
+                kind: AddItemOperation
+                value: =Topic.employeeRow
 
     - kind: SetVariable
-      id: HC2h7w
-      displayName: Merge all records in table
+      id: setVariable_P41zFQ
       variable: Topic.workdayResponseTable
-      value: |-
-        =ForAll(
-            Sequence(CountRows(Topic.WorkdayResponseRecord.WorkerID)),
-            {
-                FirstName: Last(FirstN(Topic.WorkdayResponseRecord.FirstName, Value)).Value,
-                LastName: Last(FirstN(Topic.WorkdayResponseRecord.LastName, Value)).Value,
-                CompanyCode: Last(FirstN(Topic.WorkdayResponseRecord.CompanyCode, Value)).Value,
-                CompanyName: Last(FirstN(Topic.WorkdayResponseRecord.CompanyName, Value)).Value
-            }
-        )
+      value: =Topic.workdayAllOrgResponseTable
 
     - kind: ConditionGroup
       id: conditionGroup_yepfHF

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CostCenter/README.md
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CostCenter/README.md
@@ -17,7 +17,9 @@ for each of their supervisory organizations, this scenario enables managers to v
 ## Prerequisites
 
 ### Global Variables Required
-- `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager (used to filter direct reports)
+- Check the `ManagerScenarios` folder for more details on prerequisites.
+    - `msdyn_HRWorkdayHCMEmployeeGetData` - A SOAP template for retrieving the Workday supervisory organization IDs for a manager
+    - `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager
 
 ### Workday API
 - **Service**: Human_Resources

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CostCenter/README.md
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CostCenter/README.md
@@ -1,0 +1,67 @@
+---
+nav_exclude: true
+search_exclude: false
+---
+# Workday Get Manager Reportees Cost Center
+
+## Overview
+for each of their supervisory organizations, this scenario enables managers to view their direct reports along with Cost Centers.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `topic.yaml` | Copilot Studio topic definition with trigger phrases and Power Fx logic |
+| `msdyn_HRWorkdayHCMManagerDirectCostCenter.xml` | XML template for Workday Get_Workers API call |
+
+## Prerequisites
+
+### Global Variables Required
+- `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager (used to filter direct reports)
+
+### Workday API
+- **Service**: Human_Resources
+- **Operation**: Get_Workers
+- **Version**: v41.0
+
+## Scenario Details
+
+### What It Does
+1. Retrieves all employees in all supervisory organizations for the manager (all direct reports).
+2. Extracts key employee information (Cost Center, Cost Center Name, etc.)
+3. Presents results in a formatted table
+
+### Trigger Phrases
+- Show me my team’s cost center data? 
+- What cost centers are assigned to my reports? 
+- What are my team’s cost centers?
+
+## Response Group Configuration
+
+The XML template is optimized for performance by:
+- **Including**: Reference, Personal Information, Employment Information
+- **Excluding**: Compensation, Benefits, Documents, Photos, and other unnecessary data
+
+## Setup Instructions
+
+1. **Import the Topic**: Import `topic.yaml` into your Copilot Studio agent
+2. **Add XML Template**: Upload `msdyn_HRWorkdayHCMManagerDirectCostCenter.xml.xml` to your Workday connector configuration
+3. **Configure Connection**: Ensure your Workday connector connection reference is properly set in the topic
+4. **Set Global Variable**: Make sure `Global.Manager_Supervisory_OrgIds` is populated (typically from user context setup)
+
+## Example Output
+
+When a manager asks "Show me my team's cost center", the agent displays:
+
+> # Team cost centers
+> Here’s the available information for your team’s cost centers:
+> 
+> * John Smith: Cost center information is not available.
+> * Jane Doe
+>    * Cost Center Code: CC-1
+>    * Cost Center Name: Cost Center 1
+> * Jane Smith
+>    * Cost Center Code: CC-1
+>    * Cost Center Name: Cost Center 1
+>
+> If you need further details or want to check for updates, let me know!

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CostCenter/topic.yaml
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-CostCenter/topic.yaml
@@ -35,74 +35,102 @@ beginDialog:
       displayName: Check manager status
       dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdayManagerCheck
 
-    - kind: BeginDialog
-      id: jJpz3n
-      displayName: Redirect to Workday Get Common Execution
-      input:
-        binding:
-          parameters: ="{""params"":[{""key"":""{ManagerOrgId}"",""value"":""" & Global.ESS_UserContext_ManagerOrganizationId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
-          scenarioName: msdyn_HRWorkdayHCMManagerDirectCostCenter
+    - kind: SetVariable
+      id: setVariable_OBjpUF
+      variable: Topic.workdayAllOrgResponseTable
+      value: =[]
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
-      output:
-        binding:
-          errorResponse: Topic.errorResponse
-          isSuccess: Topic.isSuccess
-          workdayResponse: Topic.workdayResponse
+    - kind: Foreach
+      id: foreach_niaz95
+      items: =Split(Global.Manager_Supervisory_OrgIds, ",")
+      value: Topic.SupOrgId
+      index: init:Topic.LoopIndex1
+      actions:
+        - kind: BeginDialog
+          id: jJpz3n
+          displayName: Redirect to Workday Get Common Execution
+          input:
+            binding:
+              parameters: ="{""params"":[{""key"":""{ManagerOrgId}"",""value"":""" & Topic.SupOrgId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
+              scenarioName: msdyn_HRWorkdayHCMManagerDirectCostCenter
 
-    - kind: ParseValue
-      id: aXVFNu
-      displayName: Parse value to a record
-      variable: Topic.workdayResponseRecord
-      valueType:
-        kind: Record
-        properties:
-          CostCenterCode:
-            type:
-              kind: Table
-              properties:
-                Value: String
+          dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+          output:
+            binding:
+              errorResponse: Topic.errorResponse
+              isSuccess: Topic.isSuccess
+              workdayResponse: Topic.workdayResponse
 
-          CostCenterName:
-            type:
-              kind: Table
-              properties:
-                Value: String
+        - kind: ParseValue
+          id: aXVFNu
+          displayName: Parse value to a record
+          variable: Topic.workdayResponseRecord
+          valueType:
+            kind: Record
+            properties:
+              CostCenterCode:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-          LegalNameData:
-            type:
-              kind: Table
-              properties:
-                Name_Detail_Data:
-                  type:
-                    kind: Record
-                    properties:
-                      @Formatted_Name: String
-                      First_Name: String
-                      Last_Name: String
+              CostCenterName:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-          WorkerID:
-            type:
-              kind: Table
-              properties:
-                Value: String
+              LegalNameData:
+                type:
+                  kind: Table
+                  properties:
+                    Name_Detail_Data:
+                      type:
+                        kind: Record
+                        properties:
+                          @Formatted_Name: String
+                          First_Name: String
+                          Last_Name: String
 
-      value: =Topic.workdayResponse
+              WorkerID:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
+
+          value: =Topic.workdayResponse
+
+        - kind: SetVariable
+          id: setVariable_ztXmui
+          displayName: Extract data to table
+          variable: Topic.workdayResponseTable
+          value: |-
+            =ForAll(
+                Sequence(CountRows(Topic.workdayResponseRecord.WorkerID)),
+                {
+                    FirstName: Last(FirstN(Topic.workdayResponseRecord.LegalNameData, Value)).Name_Detail_Data.First_Name,
+                    LastName: Last(FirstN(Topic.workdayResponseRecord.LegalNameData, Value)).Name_Detail_Data.Last_Name,
+                    CostCenterCode: Last(FirstN(Topic.workdayResponseRecord.CostCenterCode, Value)).Value,
+                    CostCenterName: Last(FirstN(Topic.workdayResponseRecord.CostCenterName, Value)).Value
+                }
+            )
+          
+        - kind: Foreach
+          id: foreach_rows_in_org
+          items: =Topic.workdayResponseTable
+          value: Topic.employeeRow
+          actions:
+            - kind: EditTableV2
+              id: editTableV2_AddWorkerRow
+              itemsVariable: Topic.workdayAllOrgResponseTable
+              changeType:
+                kind: AddItemOperation
+                value: =Topic.employeeRow
 
     - kind: SetVariable
-      id: setVariable_ztXmui
-      displayName: Extract data to table
+      id: setVariable_P41zFQ
       variable: Topic.workdayResponseTable
-      value: |-
-        =ForAll(
-            Sequence(CountRows(Topic.workdayResponseRecord.WorkerID)),
-            {
-                FirstName: Last(FirstN(Topic.workdayResponseRecord.LegalNameData, Value)).Name_Detail_Data.First_Name,
-                LastName: Last(FirstN(Topic.workdayResponseRecord.LegalNameData, Value)).Name_Detail_Data.Last_Name,
-                CostCenterCode: Last(FirstN(Topic.workdayResponseRecord.CostCenterCode, Value)).Value,
-                CostCenterName: Last(FirstN(Topic.workdayResponseRecord.CostCenterName, Value)).Value
-            }
-        )
+      value: =Topic.workdayAllOrgResponseTable
 
     - kind: ConditionGroup
       id: conditionGroup_eEjEWp

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-Jobtaxanomy/README.md
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-Jobtaxanomy/README.md
@@ -17,7 +17,9 @@ For each of their supervisory organizations, this scenario enables managers to v
 ## Prerequisites
 
 ### Global Variables Required
-- `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager (used to filter direct reports)
+- Check the `ManagerScenarios` folder for more details on prerequisites.
+    - `msdyn_HRWorkdayHCMEmployeeGetData` - A SOAP template for retrieving the Workday supervisory organization IDs for a manager
+    - `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager
 
 ### Workday API
 - **Service**: Human_Resources

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-Jobtaxanomy/README.md
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-Jobtaxanomy/README.md
@@ -1,0 +1,75 @@
+---
+nav_exclude: true
+search_exclude: false
+---
+# Workday Get Manager Reportees Job Taxonomy
+
+## Overview
+For each of their supervisory organizations, this scenario enables managers to view their direct reports along with Position details.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `topic.yaml` | Copilot Studio topic definition with trigger phrases and Power Fx logic |
+| `msdyn_HRWorkdayHCMManagerJobTaxonomy.xml` | XML template for Workday Get_Workers API call |
+
+## Prerequisites
+
+### Global Variables Required
+- `Global.Manager_Supervisory_OrgIds` - A list of all of the Workday supervisory organization IDs of a manager (used to filter direct reports)
+
+### Workday API
+- **Service**: Human_Resources
+- **Operation**: Get_Workers
+- **Version**: v41.0
+
+## Scenario Details
+
+### What It Does
+1. Retrieves all employees in all supervisory organizations for the manager (all direct reports).
+2. Extracts key employee information (Job Title, Business Title, etc.)
+3. Presents results in a formatted table
+
+### Trigger Phrases
+- Show me my team's job title?
+- What is the internal title of my direct report X?
+- What is the job function of my team?
+- What job profile is mapped to my team members?
+
+## Response Group Configuration
+
+The XML template is optimized for performance by:
+- **Including**: Reference, Personal Information, Employment Information
+- **Excluding**: Compensation, Benefits, Documents, Photos, and other unnecessary data
+
+## Setup Instructions
+
+1. **Import the Topic**: Import `topic.yaml` into your Copilot Studio agent
+2. **Add XML Template**: Upload `msdyn_HRWorkdayHCMManagerJobTaxonomy.xml` to your Workday connector configuration
+3. **Configure Connection**: Ensure your Workday connector connection reference is properly set in the topic
+4. **Set Global Variable**: Make sure `Global.Manager_Supervisory_OrgIds` is populated (typically from user context setup)
+
+## Example Output
+
+When a manager asks "Show me my team's job taxonomy", the agent displays:
+
+
+> # Team job taxonomy
+> Here’s an overview of your team’s job taxonomy:
+>
+> * John Smith
+>   * Job Title: Sales Solution Consultant
+>   * Job Family: Sales-Sales & Support
+>   * Job Profile: Sales Solution Consultant
+> * Jane Doe
+>   * Job Title: Sales Solution Consultant
+>   * Job Family: Special & Characters
+>   * Job Profile: Sales Solution Consultant
+> * Jane Smith
+>   * Job Title: Sales Solution Consultant
+>   * Job Family: Sales-Sales & Support
+>   * Job Profile: Sales Solution Consultant
+>
+> If you need more details or want to see taxonomy for a specific team member, let me know!
+

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-Jobtaxanomy/topic.yaml
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/WorkdayManagersdirect-Jobtaxanomy/topic.yaml
@@ -45,100 +45,128 @@ beginDialog:
       displayName: Check manager status
       dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdayManagerCheck
 
-    - kind: BeginDialog
-      id: 7Va4UU
-      displayName: Redirect to Workday Get Common Execution
-      input:
-        binding:
-          parameters: ="{""params"":[{""key"":""{ManagerOrgId}"",""value"":""" & Global.ESS_UserContext_ManagerOrganizationId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
-          scenarioName: msdyn_HRWorkdayHCMManagerJobTaxonomy
+    - kind: SetVariable
+      id: setVariable_OBjpUF
+      variable: Topic.workdayAllOrgResponseTable
+      value: =[]
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
-      output:
-        binding:
-          errorResponse: Topic.errorResponse
-          isSuccess: Topic.isSuccess
-          workdayResponse: Topic.workdayResponse
+    - kind: Foreach
+      id: foreach_niaz95
+      items: =Split(Global.Manager_Supervisory_OrgIds, ",")
+      value: Topic.SupOrgId
+      index: init:Topic.LoopIndex1
+      actions:
+        - kind: BeginDialog
+          id: 7Va4UU
+          displayName: Redirect to Workday Get Common Execution
+          input:
+            binding:
+              parameters: ="{""params"":[{""key"":""{ManagerOrgId}"",""value"":""" & Topic.SupOrgId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
+              scenarioName: msdyn_HRWorkdayHCMManagerJobTaxonomy
 
-    - kind: ParseValue
-      id: mq6jr0
-      displayName: Parse workdayResponse into table
-      variable: Topic.WorkdayResponseRecord
-      valueType:
-        kind: Record
-        properties:
-          BusinessTitle:
-            type:
-              kind: Table
-              properties:
-                Value: String
+          dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+          output:
+            binding:
+              errorResponse: Topic.errorResponse
+              isSuccess: Topic.isSuccess
+              workdayResponse: Topic.workdayResponse
 
-          FirstName:
-            type:
-              kind: Table
-              properties:
-                Value: String
+        - kind: ParseValue
+          id: mq6jr0
+          displayName: Parse workdayResponse into table
+          variable: Topic.WorkdayResponseRecord
+          valueType:
+            kind: Record
+            properties:
+              BusinessTitle:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-          JobFamilyId:
-            type:
-              kind: Table
-              properties:
-                Value: String
+              FirstName:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-          JobProfile:
-            type:
-              kind: Table
-              properties:
-                Value: String
+              JobFamilyId:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-          JobTitle:
-            type:
-              kind: Table
-              properties:
-                Value: String
+              JobProfile:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-          LastName:
-            type:
-              kind: Table
-              properties:
-                Value: String
+              JobTitle:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-          WorkerID:
-            type:
-              kind: Table
-              properties:
-                Value: String
+              LastName:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-      value: =Topic.workdayResponse
+              WorkerID:
+                type:
+                  kind: Table
+                  properties:
+                    Value: String
 
-    - kind: BeginDialog
-      id: QdE53O
-      displayName: Refresh JobFamily reference data
-      input:
-        binding:
-          IsTableEmpty: =IsBlank(Global.JobFamilyLookupTable)
-          ReferenceDataKey: Job_Family_ID
+          value: =Topic.workdayResponse
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemRefreshReferenceData
+        - kind: BeginDialog
+          id: QdE53O
+          displayName: Refresh JobFamily reference data
+          input:
+            binding:
+              IsTableEmpty: =IsBlank(Global.JobFamilyLookupTable)
+              ReferenceDataKey: Job_Family_ID
+
+          dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemRefreshReferenceData
+
+        - kind: SetVariable
+          id: setVariable_EFFdlM
+          displayName: Merge all records in table
+          variable: Topic.workdayResponseTable
+          value: |-
+            =ForAll(
+                Sequence(CountRows(Topic.WorkdayResponseRecord.WorkerID)),
+                {
+                    FirstName: Last(FirstN(Topic.WorkdayResponseRecord.FirstName, Value)).Value,
+                    LastName: Last(FirstN(Topic.WorkdayResponseRecord.LastName, Value)).Value,
+                    JobTitle: Last(FirstN(Topic.WorkdayResponseRecord.JobTitle, Value)).Value,
+                    BusinessTitle: Last(FirstN(Topic.WorkdayResponseRecord.BusinessTitle, Value)).Value,
+                    JobProfile: Last(FirstN(Topic.WorkdayResponseRecord.JobProfile, Value)).Value,
+                    JobFamily: LookUp(Global.JobFamilyLookupTable,
+                                ID = Last(FirstN(Topic.WorkdayResponseRecord.JobFamilyId, Value)).Value
+                            ).Referenced_Object_Descriptor
+                }
+            )
+
+        - kind: Foreach
+          id: foreach_rows_in_org
+          items: =Topic.workdayResponseTable
+          value: Topic.employeeRow
+          actions:
+            - kind: EditTableV2
+              id: editTableV2_AddWorkerRow
+              itemsVariable: Topic.workdayAllOrgResponseTable
+              changeType:
+                kind: AddItemOperation
+                value: =Topic.employeeRow
 
     - kind: SetVariable
-      id: setVariable_EFFdlM
-      displayName: Merge all records in table
+      id: setVariable_P41zFQ
       variable: Topic.workdayResponseTable
-      value: |-
-        =ForAll(
-            Sequence(CountRows(Topic.WorkdayResponseRecord.WorkerID)),
-            {
-                FirstName: Last(FirstN(Topic.WorkdayResponseRecord.FirstName, Value)).Value,
-                LastName: Last(FirstN(Topic.WorkdayResponseRecord.LastName, Value)).Value,
-                JobTitle: Last(FirstN(Topic.WorkdayResponseRecord.JobTitle, Value)).Value,
-                BusinessTitle: Last(FirstN(Topic.WorkdayResponseRecord.BusinessTitle, Value)).Value,
-                JobProfile: Last(FirstN(Topic.WorkdayResponseRecord.JobProfile, Value)).Value,
-                JobFamily: LookUp(Global.JobFamilyLookupTable,
-                            ID = Last(FirstN(Topic.WorkdayResponseRecord.JobFamilyId, Value)).Value
-                        ).Referenced_Object_Descriptor
-            }
-        )
+      value: =Topic.workdayAllOrgResponseTable
 
     - kind: ConditionGroup
       id: conditionGroup_yepfHF

--- a/EmployeeSelfServiceAgent/Workday/ManagerScenarios/msdyn_HRWorkdayHCMEmployeeGetData
+++ b/EmployeeSelfServiceAgent/Workday/ManagerScenarios/msdyn_HRWorkdayHCMEmployeeGetData
@@ -1,0 +1,70 @@
+<workdayEntityConfigurationTemplate>
+    <scenario name="HRWorkdayHCMEmployeeGetData">
+        <apiRequests>
+            <apiRequest>
+                <authType>User</authType>
+                <endpoint>
+                    <request>msdyn_HRWorkdayHCMEmployeeGetData</request>
+                    <serviceName>Human_Resources</serviceName>
+                    <version>v42.0</version>
+                </endpoint>
+                <responseProperties>
+                    <property>
+                        <extractPath>//*[local-name()='Worker']/*[local-name()='Worker_Data']/*[local-name()='Role_Data']</extractPath>
+                        <key>EmploymentData</key>
+                    </property>
+                </responseProperties>
+            </apiRequest>
+        </apiRequests>
+    </scenario>
+
+    <requestTemplates>
+        <requestTemplate name="msdyn_HRWorkdayHCMEmployeeGetData">
+            <bsvc:Get_Workers_Request xmlns:bsvc="urn:com.workday/bsvc" bsvc:version="v42.0">
+                <bsvc:Request_References
+                    bsvc:Skip_Non_Existing_Instances="false"
+                    bsvc:Ignore_Invalid_References="true">
+                    <bsvc:Worker_Reference bsvc:Descriptor="Employee_ID">
+                        <bsvc:ID bsvc:type="Employee_ID">{Employee_ID}</bsvc:ID>
+                    </bsvc:Worker_Reference>
+                </bsvc:Request_References>
+
+                <bsvc:Response_Group>
+                    <bsvc:Include_Reference>true</bsvc:Include_Reference>
+                    <bsvc:Include_Personal_Information>true</bsvc:Include_Personal_Information>
+                    <bsvc:Include_Additional_Jobs>true</bsvc:Include_Additional_Jobs>
+                    <bsvc:Include_Employment_Information>true</bsvc:Include_Employment_Information>
+                    <bsvc:Include_Compensation>true</bsvc:Include_Compensation>
+                    <bsvc:Include_Organizations>true</bsvc:Include_Organizations>
+
+                    <!-- EXCLUDES flipped to false -->
+                    <bsvc:Exclude_Organization_Support_Role_Data>false</bsvc:Exclude_Organization_Support_Role_Data>
+                    <bsvc:Exclude_Location_Hierarchies>false</bsvc:Exclude_Location_Hierarchies>
+                    <bsvc:Exclude_Cost_Centers>false</bsvc:Exclude_Cost_Centers>
+                    <bsvc:Exclude_Cost_Center_Hierarchies>false</bsvc:Exclude_Cost_Center_Hierarchies>
+                    <bsvc:Exclude_Companies>false</bsvc:Exclude_Companies>
+                    <bsvc:Exclude_Company_Hierarchies>false</bsvc:Exclude_Company_Hierarchies>
+                    <bsvc:Exclude_Matrix_Organizations>false</bsvc:Exclude_Matrix_Organizations>
+                    <bsvc:Exclude_Pay_Groups>false</bsvc:Exclude_Pay_Groups>
+                    <bsvc:Exclude_Regions>false</bsvc:Exclude_Regions>
+                    <bsvc:Exclude_Region_Hierarchies>false</bsvc:Exclude_Region_Hierarchies>
+                    <bsvc:Exclude_Supervisory_Organizations>false</bsvc:Exclude_Supervisory_Organizations>
+                    <bsvc:Exclude_Teams>false</bsvc:Exclude_Teams>
+                    <bsvc:Exclude_Custom_Organizations>false</bsvc:Exclude_Custom_Organizations>
+
+                    <!-- More EXCLUDES flipped -->
+                    <bsvc:Exclude_Funds>false</bsvc:Exclude_Funds>
+                    <bsvc:Exclude_Fund_Hierarchies>false</bsvc:Exclude_Fund_Hierarchies>
+                    <bsvc:Exclude_Grants>false</bsvc:Exclude_Grants>
+                    <bsvc:Exclude_Grant_Hierarchies>false</bsvc:Exclude_Grant_Hierarchies>
+                    <bsvc:Exclude_Business_Units>false</bsvc:Exclude_Business_Units>
+                    <bsvc:Exclude_Business_Unit_Hierarchies>false</bsvc:Exclude_Business_Unit_Hierarchies>
+                    <bsvc:Exclude_Programs>false</bsvc:Exclude_Programs>
+                    <bsvc:Exclude_Program_Hierarchies>false</bsvc:Exclude_Program_Hierarchies>
+                    <bsvc:Exclude_Gifts>false</bsvc:Exclude_Gifts>
+                    <bsvc:Exclude_Gift_Hierarchies>false</bsvc:Exclude_Gift_Hierarchies>
+                </bsvc:Response_Group>
+            </bsvc:Get_Workers_Request>
+        </requestTemplate>
+    </requestTemplates>
+</workdayEntityConfigurationTemplate>


### PR DESCRIPTION
Uses a list of Supervisory Org Ids provided by user context setup to loop through any Workday topics for a manager's direct reports