### PR TITLE
Add ESS team as codeowners for EmployeeSelfServiceAgent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,6 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 * @adilei @HenryJammes
+
+# ESS team owns their own content
+/EmployeeSelfServiceAgent/ @microsoft/ess-contributors


### PR DESCRIPTION
## Summary
- Adds `@microsoft/ess-contributors` as codeowners for `/EmployeeSelfServiceAgent/`
- ESS team members can now review and approve each other's PRs without requiring repo maintainer review
- Team already has write access to the repo

## Details
The `@microsoft/ess-contributors` team (`@srideshpande`, `@SurendraGoutham`, `@nkemms`) regularly submits PRs that only touch `EmployeeSelfServiceAgent/`. This change lets them self-manage their directory using CODEOWNERS path scoping (last-match-wins).

PRs touching files outside `EmployeeSelfServiceAgent/` still require `@adilei` / `@HenryJammes` review as before.

## Test plan
- [ ] Verify an ESS member's PR to `EmployeeSelfServiceAgent/` requests only `@microsoft/ess-contributors`
- [ ] Verify a PR touching other paths still requests `@adilei` / `@HenryJammes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)