### PR TITLE
Fix 404 on assistant-ui custom UI sample page

### DIFF
--- a/ui/custom-ui/assistant-ui/README.md
+++ b/ui/custom-ui/assistant-ui/README.md
@@ -1,3 +1,9 @@
+---
+title: Assistant UI
+parent: Custom UI
+grand_parent: UI
+nav_order: 3
+---
 # Copilot Studio + Assistant UI Integration Sample
 
 This project demonstrates how to integrate Copilot Studio with Assistant UI to create a modern, responsive chat interface with AI capabilities.
@@ -10,7 +16,7 @@ This sample showcases:
 - Multiple conversation threads
 
 <p align="center">
-  <img src="./docs/images/screenshot.png" alt="Screenshot of the Assistant UI with Copilot Studio">
+  <img src="./assistant-ui-mcs/docs/images/screenshot.png" alt="Screenshot of the Assistant UI with Copilot Studio">
 </p>
 
 ## Prerequisites
@@ -50,18 +56,12 @@ This sample showcases:
 1. Clone this repository and navigate to the project directory:
    ```bash
    git clone https://github.com/microsoft/CopilotStudioSamples
-   cd CopilotStudioSamples/AssistantUICopilotStudioClient/assistant-ui-mcs
+   cd CopilotStudioSamples/ui/custom-ui/assistant-ui/assistant-ui-mcs
    ```
 
 2. Install dependencies:
    ```bash
    npm install
-   # or
-   yarn install
-   # or
-   pnpm install
-   # or
-   bun install
    ```
 3. Create a `.env.local` file in the root of the project and add the following environment variables:
    ```env
@@ -75,12 +75,6 @@ This sample showcases:
 4. Start the development server:
    ```bash
    npm run dev
-   # or
-   yarn dev
-   # or
-   pnpm dev
-   # or
-   bun dev
    ```
 5. Open your browser and navigate to `http://localhost:3000` to see the application in action.
 6. You will be prompted to sign in with Microsoft credentials


### PR DESCRIPTION
## Summary
- The `/ui/custom-ui/assistant-ui/` page was returning a 404 because there was no `README.md` in the directory — the content lived one level deeper in `assistant-ui-mcs/`
- Added a `README.md` at the correct level with the sample content and adjusted paths
- Stripped Jekyll front matter from the nested copy to prevent duplicate pages

## Test plan
- [ ] Verify https://microsoft.github.io/CopilotStudioSamples/ui/custom-ui/assistant-ui/ no longer 404s
- [ ] Verify the page appears correctly in the sidebar nav under Custom UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)