### PR TITLE
Update WorkdayDA topics to reference DA HR agent schema

### DIFF
--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/EmployeeAddDependents/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/EmployeeAddDependents/topic.yaml
@@ -60,7 +60,7 @@ beginDialog:
               input:
                 binding:
                   referenceDataKey: Related_Person_Relationship_ID
-              dialog: msdyn_copilotforemployeeselfservicehr.topic.GetReferenceData
+              dialog: msdyn_copilotforemployeeselfservicedahr.topic.GetReferenceData
 
     # Step 2: Fetch existing dependents
     - kind: BeginDialog
@@ -70,7 +70,7 @@ beginDialog:
         binding:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Now(), "yyyy-MM-dd") &"""}]}"
           scenarioName: msdyn_HRWorkdayHCMEmployeeGetDependents
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse
@@ -334,7 +334,7 @@ beginDialog:
         binding:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{First_Name}"",""value"":""" & Topic.firstName & """},{""key"":""{Last_Name}"",""value"":""" & Topic.lastName & """},{""key"":""{Date_Of_Birth}"",""value"":""" & Topic.dateOfBirth & """},{""key"":""{Gender}"",""value"":""" & Topic.gender & """},{""key"":""{Relationship_Type}"",""value"":""" & Topic.relationshipTypeId & """},{""key"":""{Country_Code}"",""value"":""" & Topic.country & """}]}"
           scenarioName: msdyn_HRWorkdayHCMEmployeeAddDependent
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.addErrorResponse

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/EmployeeGetVacationBalance/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/EmployeeGetVacationBalance/topic.yaml
@@ -107,7 +107,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Topic.AsOfEffectiveDate, "yyyy-MM-dd") &"""}]}"
           scenarioName: msdyn_HRWorkdayHCMEmployeeGetVacationBalance
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayEmployeeRequestTimeOff/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayEmployeeRequestTimeOff/topic.yaml
@@ -150,7 +150,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":""" & Text(Topic.AsOfEffectiveDate, "yyyy-MM-dd") & """}]}"
           scenarioName: msdyn_HRWorkdayHCMEmployeeGetVacationBalance
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.balanceErrorResponse
@@ -651,7 +651,7 @@ beginDialog:
             "]}"
           scenarioName: msdyn_HRWorkdayAbsenceEnterTimeOff_MultiDay
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayEmployeesviewtheirjobtaxonomy/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayEmployeesviewtheirjobtaxonomy/topic.yaml
@@ -30,7 +30,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: msdyn_HRWorkdayHCMEmployeeGetJobTaxonomy
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse
@@ -89,7 +89,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{Job_Family_ID}"",""value"":""" & Topic.transformResponse.JobFamilyId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: msdyn_HRWorkdayHCMEmployeeGetJobTaxonomyGeneric
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetContactInformation/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetContactInformation/topic.yaml
@@ -45,7 +45,7 @@ beginDialog:
         binding:
           EmployeeName: =Topic.EmployeeName
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemAccessCheck
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemAccessCheck
 
     - kind: BeginDialog
       id: Z6efSa
@@ -55,7 +55,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: ="msdyn_HRWorkdayHCMEmployeeGetWorkContactInformation"
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse
@@ -193,7 +193,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: ="msdyn_HRWorkdayHCMEmployeeGetHomeContactInformation"
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse
@@ -338,7 +338,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: ="msdyn_HRWorkdayHCMEmployeeGetWorkAddress"
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetEducation/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetEducation/topic.yaml
@@ -34,7 +34,7 @@ beginDialog:
         binding:
           EmployeeName: =Topic.EmployeeName
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemAccessCheck
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemAccessCheck
 
     - kind: BeginDialog
       id: B7ae9T
@@ -44,7 +44,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: ="msdyn_HRWorkdayHCMEmployeeGetEducation"
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse
@@ -151,7 +151,7 @@ beginDialog:
           IsTableEmpty: =IsBlank(Global.CountryNameLookupTable)
           ReferenceDataKey: ISO_3166-1_Alpha-2_Code
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemRefreshReferenceData
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemRefreshReferenceData
 
     - kind: BeginDialog
       id: iM5A5i
@@ -161,7 +161,7 @@ beginDialog:
           IsTableEmpty: =IsBlank(Global.DegreeTypeLookupTable)
           ReferenceDataKey: Degree_ID
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemRefreshReferenceData
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemRefreshReferenceData
 
     - kind: BeginDialog
       id: zG3du7
@@ -171,7 +171,7 @@ beginDialog:
           IsTableEmpty: =IsBlank(Global.FieldOfStudyLookupTable)
           ReferenceDataKey: Field_Of_Study_ID
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemRefreshReferenceData
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemRefreshReferenceData
 
     - kind: SetVariable
       id: setVariable_nD5Gkb

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetGovernmentIDs/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetGovernmentIDs/topic.yaml
@@ -32,7 +32,7 @@ beginDialog:
         binding:
           EmployeeName: =Topic.EmployeeName
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemAccessCheck
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemAccessCheck
 
     - kind: BeginDialog
       id: 3bFDxH
@@ -42,7 +42,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: ="msdyn_HRWorkdayHCMEmployeeGetGovernmentIds"
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse
@@ -96,7 +96,7 @@ beginDialog:
           IsTableEmpty: =IsBlank(Global.CountryNameLookupTable)
           ReferenceDataKey: ISO_3166-1_Alpha-2_Code
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemRefreshReferenceData
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemRefreshReferenceData
 
     - kind: BeginDialog
       id: Xoydcu
@@ -106,7 +106,7 @@ beginDialog:
           IsTableEmpty: =IsBlank(Global.GovernmentIdTypeLookupTable)
           ReferenceDataKey: Government_ID_Type_ID
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemRefreshReferenceData
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemRefreshReferenceData
 
     - kind: SetVariable
       id: setVariable_ZYrAxQ

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetUserProfile/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetUserProfile/topic.yaml
@@ -58,7 +58,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: msdyn_HRWorkdayHCMEmployeeGetUserProfile
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGivePeerFeedback/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGivePeerFeedback/topic.yaml
@@ -52,7 +52,7 @@ beginDialog:
                   parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """}, {""key"":""{Employee_ID_Of_Receiver}"",""value"":"""& Topic.varEmployeeId & """}, {""key"":""{Comment}"",""value"":""" & Topic.FeedbackText & """}]}"
                   scenarioName: msdyn_HRWorkdayHCMEmployeeGiveFeedback
 
-              dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+              dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
               output:
                 binding:
                   errorResponse: Topic.errorResponse

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayManageEmergencyContact/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayManageEmergencyContact/topic.yaml
@@ -47,7 +47,7 @@ beginDialog:
                 binding:
                   referenceDataKey: Country_Phone_Code_ID
 
-              dialog: msdyn_copilotforemployeeselfservicehr.topic.GetReferenceData
+              dialog: msdyn_copilotforemployeeselfservicedahr.topic.GetReferenceData
 
     - kind: ConditionGroup
       id: check_relationship_types
@@ -63,7 +63,7 @@ beginDialog:
                 binding:
                   referenceDataKey: Related_Person_Relationship_ID
 
-              dialog: msdyn_copilotforemployeeselfservicehr.topic.GetReferenceData
+              dialog: msdyn_copilotforemployeeselfservicedahr.topic.GetReferenceData
 
     - kind: ConditionGroup
       id: check_state_province_choices
@@ -231,7 +231,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: msdyn_HRWorkdayHCMEmployeeGetEmergencyContactInfo
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.fetchErrorResponse
@@ -1137,7 +1137,7 @@ beginDialog:
                               parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{Emergency_Contact_WID}"",""value"":""" & Topic.selectedContactWID & """},{""key"":""{Priority}"",""value"":""" & Topic.selectedContactData.Priority & """},{""key"":""{Relationship_Type}"",""value"":""" & Topic.selectedContactData.RelationshipTypeID & """},{""key"":""{Comment}"",""value"":""Removing emergency contact via Copilot""}]}"
                               scenarioName: msdyn_DeleteEmergencyContact
 
-                          dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+                          dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
                           output:
                             binding:
                               errorResponse: Topic.errorResponse
@@ -1246,7 +1246,7 @@ beginDialog:
                           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{Emergency_Contact_WID}"",""value"":""" & Topic.selectedContactWID & """},{""key"":""{Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""},{""key"":""{First_Name}"",""value"":""" & Topic.firstName & """},{""key"":""{Last_Name}"",""value"":""" & Topic.lastName & """},{""key"":""{Primary}"",""value"":""" & Topic.isPrimaryContact & """},{""key"":""{Priority}"",""value"":""" & If(Topic.isPrimaryContact = "true", "1", Topic.priority) & """},{""key"":""{Relationship_Type}"",""value"":""" & Topic.relationshipType & """},{""key"":""{Phone_Number}"",""value"":""" & Topic.phoneNumber & """},{""key"":""{Phone_Device_Type}"",""value"":""" & Topic.phoneDeviceType & """},{""key"":""{Phone_Country_Code}"",""value"":""" & Last(Split(Topic.phoneCountryCode, "_")).Value & """},{""key"":""{Address_Line_1}"",""value"":""" & Topic.addressLine1 & """},{""key"":""{City}"",""value"":""" & Topic.city & """},{""key"":""{State_Province}"",""value"":""" & Topic.stateProvince & """},{""key"":""{Postal_Code}"",""value"":""" & Topic.postalCode & """},{""key"":""{Country_Code}"",""value"":""" & Topic.countryCode & """},{""key"":""{Address_Country_Code}"",""value"":""" & Topic.countryCode & """},{""key"":""{Comment}"",""value"":""Updating emergency contact""}]}"
                           scenarioName: msdyn_UpdateEmergencyContact
 
-                      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+                      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
                       output:
                         binding:
                           errorResponse: Topic.errorResponse
@@ -1262,7 +1262,7 @@ beginDialog:
                       parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""},{""key"":""{First_Name}"",""value"":""" & Topic.firstName & """},{""key"":""{Last_Name}"",""value"":""" & Topic.lastName & """},{""key"":""{Primary}"",""value"":""" & Topic.isPrimaryContact & """},{""key"":""{Priority}"",""value"":""" & If(Topic.isPrimaryContact = "true", "1", Topic.priority) & """},{""key"":""{Relationship_Type}"",""value"":""" & Topic.relationshipType & """},{""key"":""{Phone_Number}"",""value"":""" & Topic.phoneNumber & """},{""key"":""{Phone_Device_Type}"",""value"":""" & Topic.phoneDeviceType & """},{""key"":""{Phone_Country_Code}"",""value"":""" & Last(Split(Topic.phoneCountryCode, "_")).Value & """},{""key"":""{Address_Line_1}"",""value"":""" & Topic.addressLine1 & """},{""key"":""{City}"",""value"":""" & Topic.city & """},{""key"":""{State_Province}"",""value"":""" & Topic.stateProvince & """},{""key"":""{Postal_Code}"",""value"":""" & Topic.postalCode & """},{""key"":""{Country_Code}"",""value"":""" & Topic.countryCode & """},{""key"":""{Address_Country_Code}"",""value"":""" & Topic.countryCode & """},{""key"":""{Comment}"",""value"":""Adding emergency contact""}]}"
                       scenarioName: msdyn_HRWorkdayHCMEmployeeAddEmergencyContact
 
-                  dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+                  dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
                   output:
                     binding:
                       errorResponse: Topic.errorResponse

--- a/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition/topic.yaml
@@ -30,7 +30,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{Manager_Org_ID}"",""value"":""" & Global.ESS_UserContext_ManagerOrganizationId & """}]}"
           scenarioName: msdyn_GetManagerReportees
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse

--- a/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagerServiceAnniversary/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagerServiceAnniversary/topic.yaml
@@ -56,7 +56,7 @@ beginDialog:
     - kind: BeginDialog
       id: WmAHrc
       displayName: Check manager criteria
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdayManagerCheck
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdayManagerCheck
 
     - kind: SetVariable
       id: setVariable_FrkyzI
@@ -72,7 +72,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{ManagerOrgId}"",""value"":""" & Global.ESS_UserContext_ManagerOrganizationId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: msdyn_HRWorkdayHCMManagerServiceAnniversary
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse

--- a/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagersdirect-CompanyCode/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagersdirect-CompanyCode/topic.yaml
@@ -38,7 +38,7 @@ beginDialog:
     - kind: BeginDialog
       id: dAhS4T
       displayName: Check manager status
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdayManagerCheck
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdayManagerCheck
 
     - kind: BeginDialog
       id: Gt044B
@@ -48,7 +48,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{ManagerOrgId}"",""value"":""" & Global.ESS_UserContext_ManagerOrganizationId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: msdyn_HRWorkdayHCMManagerDirectCompanyCode
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse

--- a/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagersdirect-CostCenter/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagersdirect-CostCenter/topic.yaml
@@ -42,7 +42,7 @@ beginDialog:
     - kind: BeginDialog
       id: 3VGa9O
       displayName: Check manager status
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdayManagerCheck
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdayManagerCheck
 
     - kind: BeginDialog
       id: jJpz3n
@@ -52,7 +52,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{ManagerOrgId}"",""value"":""" & Global.ESS_UserContext_ManagerOrganizationId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: ="msdyn_HRWorkdayHCMManagerDirectCostCenter"
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse

--- a/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagersdirect-Jobtaxanomy/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagersdirect-Jobtaxanomy/topic.yaml
@@ -50,7 +50,7 @@ beginDialog:
     - kind: BeginDialog
       id: Y8gqWh
       displayName: Check manager status
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdayManagerCheck
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdayManagerCheck
 
     - kind: BeginDialog
       id: 7Va4UU
@@ -60,7 +60,7 @@ beginDialog:
           parameters: ="{""params"":[{""key"":""{ManagerOrgId}"",""value"":""" & Global.ESS_UserContext_ManagerOrganizationId & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
           scenarioName: msdyn_HRWorkdayHCMManagerJobTaxonomy
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemGetCommonExecution
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
         binding:
           errorResponse: Topic.errorResponse
@@ -126,7 +126,7 @@ beginDialog:
           IsTableEmpty: =IsBlank(Global.JobFamilyLookupTable)
           ReferenceDataKey: Job_Family_ID
 
-      dialog: msdyn_copilotforemployeeselfservicehr.topic.WorkdaySystemRefreshReferenceData
+      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemRefreshReferenceData
 
     - kind: SetVariable
       id: setVariable_EFFdlM


### PR DESCRIPTION
## Summary

- Repoints all `dialog:` references in WorkdayDA `topic.yaml` files from `msdyn_copilotforemployeeselfservicehr.*` to `msdyn_copilotforemployeeselfservicedahr.*` so the topics resolve to the DA-variant HR agent's `WorkdaySystem*` common-execution dialogs (schema update for the DA agent variant).
- Scope: 15 `topic.yaml` files across `EmployeeScenarios/` and `ManagerScenarios/`; 39 dialog references updated total.
- No changes outside `EmployeeSelfServiceAgent/WorkdayDA/`.

## Files updated

**EmployeeScenarios (10):** EmployeeAddDependents, EmployeeGetVacationBalance, WorkdayEmployeeRequestTimeOff, WorkdayEmployeesviewtheirjobtaxonomy, WorkdayGetContactInformation, WorkdayGetEducation, WorkdayGetGovernmentIDs, WorkdayGetUserProfile, WorkdayGivePeerFeedback, WorkdayManageEmergencyContact

**ManagerScenarios (5):** WorkdayGetManagerReporteesTimeInPosition, WorkdayManagerServiceAnniversary, WorkdayManagersdirect-CompanyCode, WorkdayManagersdirect-CostCenter, WorkdayManagersdirect-Jobtaxanomy

## Test plan
- [ ] Import a representative topic into the DA HR agent and confirm the `WorkdaySystemGetCommonExecution` / `WorkdaySystemAccessCheck` / `GetReferenceData` dialog calls resolve correctly
- [ ] Smoke-test one Employee scenario and one Manager scenario end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)