### PR TITLE
Fix eval set for GPT 53 upgrade

### DIFF
--- a/EmployeeSelfServiceAgent/ESSEvaluationSamples/StarterTestSets/Workday.csv
+++ b/EmployeeSelfServiceAgent/ESSEvaluationSamples/StarterTestSets/Workday.csv
@@ -18,5 +18,5 @@ What is my official job title?,Official job title,CompareMeaning,70
 Do I have access to view my compensation data?,Base compensation visibility and amount,CompareMeaning,70
 Are there any trainings and certifications needed for my role?,Required trainings or certifications for role,CompareMeaning,70
 Where can I see my official work location?,Official work location,CompareMeaning,70
-Can I update my preferred language for HR communications?,Preferred language information and update process,CompareMeaning,70
+What is my language preference and how can I update it for HR communication?,Preferred language information and update process,CompareMeaning,70
 Show me my hire date and my rehire date if I have one.,Hire date and rehire date,CompareMeaning,70

--- a/EmployeeSelfServiceAgent/ESSEvaluationSamples/TemplatedTestSets/Workday.csv
+++ b/EmployeeSelfServiceAgent/ESSEvaluationSamples/TemplatedTestSets/Workday.csv
@@ -18,5 +18,5 @@ What is my official job title?,Job title <Title>,CompareMeaning,70
 Do I have access to view my compensation data?,Base compensation <Amount + Currency>,CompareMeaning,70
 Are there any trainings and certifications needed for my role?,Required trainings or certifications <List>,CompareMeaning,70
 Where can I see my official work location?,Work location <Location>,CompareMeaning,70
-Can I update my preferred language for HR communications?,Preferred language information <List>,CompareMeaning,70
+What is my language preference and how can I update it for HR communication?,Preferred language information <List>,CompareMeaning,70
 Show me my hire date and my rehire date if I have one.,Hire date <MM/DD/YYYY> and rehire date <MM/DD/YYYY or None>,CompareMeaning,70


### PR DESCRIPTION
 ## Why prompt changes are needed between model upgrades

  Eval prompts are **not model-agnostic**. Each model generation interprets intent,
  phrasing, and ambiguity differently — a query that resolves cleanly on one model can
   become ambiguous on the next.

  In this case, GPT-5.3 was reading the yes/no framing (_"Can I…?"_) as a
  **permissions** question rather than the intended **info + update-process** intent.
  The reworded query makes both sub-intents explicit.

  > 🔑 When we upgrade the underlying model, eval sets must be re-tuned so the
  scorecard measures **agent quality**, not phrasing artifacts the new model handles
  differently. Otherwise regressions reflect prompt drift, not real behavior changes.

  ---

  ## Test plan

  - [ ] Re-run ESS eval suite against GPT-5.3
  - [ ] Confirm the reworded query scores ≥ threshold on `CompareMeaning`
  - [ ] Spot-check no regression on prior model baseline