### PR TITLE
PDF Page-specific citations for SharePoint as a Knowledge Source

### DIFF
--- a/authoring/snippets/topics/README.md
+++ b/authoring/snippets/topics/README.md
@@ -9,3 +9,4 @@ Copy-paste topic YAML snippets for Copilot Studio.
 | Folder | Description |
 | --- | --- |
 | [citation-swap/](./citation-swap/) | Swap AI-generated citations with custom formatting |
+| [sharepoint-pdf-page-specific-citations/](./sharepoint-pdf-page-specific-citations/) | Page-specific PDF citations for SharePoint knowledge sources |

--- a/authoring/snippets/topics/sharepoint-pdf-page-specific-citations/README.md
+++ b/authoring/snippets/topics/sharepoint-pdf-page-specific-citations/README.md
@@ -1,0 +1,41 @@
+---
+title: PDF Page-Specific Citations for SharePoint as a Knowledge Source
+parent: Snippets
+grand_parent: Authoring
+nav_order: 2
+---
+# PDF Page-Specific Citations for SharePoint as a Knowledge Source
+
+Sample topic that enhances the default citation behaviour for PDFs when using [**SharePoint as a knowledge source**](https://learn.microsoft.com/en-us/microsoft-copilot-studio/knowledge-add-sharepoint) in Copilot Studio. When a generative answer cites a PDF stored in SharePoint and page markers are provided in the citations table, this topic rewrites the citation URL to include the specific page number (`#page=N`), so users are taken directly to the relevant page rather than just the document.
+
+An optional variable is included to control whether Office files (Word, Excel, PowerPoint) are forced to open in the browser or in the desktop app. This gives makers flexibility to match their organisation's preferred file-opening behaviour.
+
+## Features
+
+- **Page-specific PDF citations** — appends `#page=N` to PDF links using page markers **when** they are returned by the SharePoint knowledge source.
+- **Optional Office web-open control** — a configurable variable that, when enabled, appends web=1 parameter to Office file links to open in the browser instead of the desktop app. 
+- Works with SharePoint knowledge sources and Generative Orchestration. When page markers are returned by SharePoint for PDFs in the System.Citations table variable in Copilot Studio, the format for a page marker is different to the format used for [Unstructured data as a knowledge source](https://learn.microsoft.com/en-us/microsoft-copilot-studio/knowledge-unstructured-data), for example uploaded files. For uploaded file scenarios, refer to [citation-swap](../citation-swap/).
+
+## Prerequisites
+
+- A Copilot Studio agent with **Generative Orchestration** enabled.
+- One or more **SharePoint** knowledge sources configured that contain PDF documents.
+
+## Instructions
+
+1. In your agent, ensure you have a SharePoint knowledge source configured, and that it contains PDFs.
+2. Create a new topic, switch to the **Code editor** view, and paste the contents of the YAML file below.
+3. Review the optional `openInBrowser` variable — set it to `true` if you want Office files to open in the browser instead of Office desktop apps.
+4. Save the topic and test by asking a question that will cite a PDF document.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [sharepoint-pdf-citations.yml](./sharepoint-pdf-citations.yml) | Topic YAML for page-specific citations for PDFs when using SharePoint as a knowledge source — paste this into the Code editor for a new topic |
+
+## Limitations
+
+- Page-specific linking only works for **PDF** files. Other file types will link to the document without a page anchor.
+- The page metadata (`<page_#>`) must be present in the citation text returned by the knowledge source; if it is missing, the link falls back to the document root. Page markers are sometimes not returned in citations for PDF files. This sample lets you use the page marker data when it is available.
+- Currently handles only the first page a chunk was returned from to ground the generative answers response. If several pages were used to ground the response, the citation emitted will point to the first page a chunk came from for the relevant PDF document.

--- a/authoring/snippets/topics/sharepoint-pdf-page-specific-citations/sharepoint-pdf-citations.yml
+++ b/authoring/snippets/topics/sharepoint-pdf-page-specific-citations/sharepoint-pdf-citations.yml
@@ -1,0 +1,141 @@
+kind: AdaptiveDialog
+beginDialog:
+  kind: OnGeneratedResponse
+  id: main
+  priority: -1
+  actions:
+    - kind: SetVariable
+      id: setVariable_HJ0sml
+      displayName: Control whether Office Files should open in the web
+      variable: Topic.OpenOfficeFilesInWeb
+      value: =true
+
+    - kind: SetVariable
+      id: rZYmg1
+      displayName: Store citations table
+      variable: Topic.SystemCitations
+      value: =System.Response.Citations
+
+    - kind: SetVariable
+      id: MHFmGu
+      displayName: Store orchestrators response
+      variable: Topic.SystemResponseText
+      value: =System.Response.FormattedText
+
+    - kind: ConditionGroup
+      id: has-answer-conditions
+      conditions:
+        - id: has-answer
+          condition: =CountRows(System.Response.Citations)>0
+          displayName: Only customise when citations are present
+          actions:
+            - kind: SetVariable
+              id: setVariable_responseBody
+              displayName: Response with citations table removed
+              variable: Topic.ResponseBodyWithoutCitations
+              value: |-
+                =If(
+                    // Look for citations footer after two line breaks and proceed if location was greater than zero (found)
+                    Find(Char(10) & Char(10) & "[1]:", System.Response.FormattedText) > 0,
+
+                    // Return everything prior to the citations footer
+                    Left(
+                        System.Response.FormattedText,
+                        Find(Char(10) & Char(10) & "[1]:", System.Response.FormattedText) - 1
+                    ),
+                    If(
+                        // Look for citations footer after a single line break and proceed if location was greater than zero (found)
+                        Find(Char(10) & "[1]:", System.Response.FormattedText) > 0,
+
+                        // Return everything prior to the citations footer
+                        Left(
+                            System.Response.FormattedText,
+                            Find(Char(10) & "[1]:", System.Response.FormattedText) - 1
+                        ),
+                        // Fallback to text response if we couldn't find the citations footer
+                        System.Response.FormattedText
+                    )
+                )
+
+            - kind: SetVariable
+              id: setVariable_EjZ42D
+              displayName: Customise citations with PDF page references
+              variable: Topic.CitationsSnip
+              value: |-
+                =Concat(
+                    // Create an index (starts at 1) for the citations held in the table allowing us to iterate through citations and generate numbered references
+                    Sequence(CountRows(System.Response.Citations)),
+                    // 
+                    With(
+                        {
+                            // Get the Nth citation from the citations table 
+                            citation: Last(FirstN(System.Response.Citations, Value)),
+                            // Convert the current citation index to text for use in the citations footer
+                            citationIndex: Text(Value)
+                        },
+                        With(
+                            {
+                                // If the citation is a PDF, append the page number with #page=X to the URL
+                                // If the citation is an Office file and OpenOfficeFilesInWeb is true, append web=1
+                                // Otherwise use the original URL
+                                resolvedUrl: If(
+                                    EndsWith(citation.Name, ".pdf"),
+                                    // Logic to add the page number for PDFs
+                                    citation.Url & "#page=" &
+                                    If(
+                                        // Only add a page number if the <page_X> marker could be found/was returned in the citations table
+                                        Find("<page_", citation.Text) > 0,
+                                        // Extract page number from the marker
+                                        Mid(
+                                            citation.Text,
+                                            Find("<page_", citation.Text) + Len("<page_"),
+                                            Find(">", citation.Text, Find("<page_", citation.Text)) - Find("<page_", citation.Text) - Len("<page_")
+                                        ),
+                                        // If there was no page marker found, default to 1
+                                        "1"
+                                    ),
+                                      If(
+                                        Topic.OpenOfficeFilesInWeb And
+                                        Or(
+                                          EndsWith(Lower(citation.Name), ".doc"),
+                                          EndsWith(Lower(citation.Name), ".docx"),
+                                          EndsWith(Lower(citation.Name), ".ppt"),
+                                          EndsWith(Lower(citation.Name), ".pptx"),
+                                          EndsWith(Lower(citation.Name), ".xls"),
+                                          EndsWith(Lower(citation.Name), ".xlsx")
+                                        ),
+                                        // For Office files, add web=1 unless it already exists
+                                        If(
+                                          Find("web=1", Lower(citation.Url)) > 0,
+                                          citation.Url,
+                                          citation.Url & If(Find("?", citation.Url) > 0, "&web=1", "?web=1")
+                                        ),
+                                        // Fall back for non-PDF/non-Office files, or when the switch is false
+                                        citation.Url
+                                      )
+                                )
+                            },
+                            // Format the markdown citations footer
+                            "[" & citationIndex & "]: " & resolvedUrl & " """ & citation.Name & """"
+                        )
+                    ),
+                    // Line break
+                    Char(10)
+                )
+
+            - kind: SendActivity
+              id: sendActivity_FplCvD
+              displayName: Respond with formatted response + new citations table
+              activity: |-
+                {
+                            Topic.ResponseBodyWithoutCitations & Char(10) & Char(10) & Text(Topic.CitationsSnip)}
+
+            - kind: SetVariable
+              id: setVariable_jrTAIw
+              displayName: Prevent orchestrator from responding directly
+              variable: System.ContinueResponse
+              value: =false
+
+            - kind: EndDialog
+              id: end-topic
+              clearTopicQueue: true


### PR DESCRIPTION
This pull request adds a new topic snippet for Copilot Studio that enhances how PDF citations are handled when using SharePoint as a knowledge source. The main improvement is to update citation links so that, when page markers are available, they direct users to the specific page within a PDF document referenced by a generative answer, rather than just the 1st page every time. The snippet also introduces an option to control whether Office files open in the browser or desktop app.

* Documentation:
  - Added `sharepoint-pdf-page-specific-citations/` to the list of available topic snippets, describing its purpose for page-specific PDF citations with SharePoint knowledge sources.
  - Created a detailed `README.md` for the new snippet, explaining its features, prerequisites, instructions, and limitations.

* Topic YAML:
  - Introduced `sharepoint-pdf-citations.yml`, a topic that:
    - Runs OnResponseGenerated to intercept the response being sent by the orchestrator for customisation
    - Detects PDF citations and appends the correct `#page=N` anchor to links when page markers are present in the citations table (these are intermittently available).
    - Adds an optional variable to force Office files to open in the browser via a `web=1` parameter.
    - Customizes the citations footer and prevents the orchestrator from sending the default response.