### PR TITLE
Fix broken relative link for GitHub Pages site

### DIFF
--- a/authoring/snippets/topics/sharepoint-pdf-page-citations/README.md
+++ b/authoring/snippets/topics/sharepoint-pdf-page-citations/README.md
@@ -38,7 +38,7 @@ An optional variable is included to control whether Office files (Word, Excel, P
 
 | File | Description |
 |------|-------------|
-| [sharepoint-pdf-citations.yml](./sharepoint-pdf-citations.yml) | Topic YAML for page-specific citations for PDFs when using SharePoint as a knowledge source — paste this into the Code editor for a new topic |
+| [sharepoint-pdf-citations.yml](https://github.com/microsoft/CopilotStudioSamples/blob/main/authoring/snippets/topics/sharepoint-pdf-page-citations/sharepoint-pdf-citations.yml) | Topic YAML for page-specific citations for PDFs when using SharePoint as a knowledge source — paste this into the Code editor for a new topic |
 
 ## Limitations
 


### PR DESCRIPTION
Removes relative link for the YAML file on the sample README.md as the GitHub Pages site doesn't handle the file. This needs to open in Github.com