### PR TITLE
fix(workday-da): emit response data from Workday READ topics so DA agents return results

### DIFF
--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/EmployeeGetVacationBalance/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/EmployeeGetVacationBalance/topic.yaml
@@ -121,6 +121,12 @@ beginDialog:
       userInput: =Topic.workdayResponse
       additionalInstructions: Do not show citation. Display each vacation balances in a separate line and highlight vacation name. Only reply back with the Vacation Balance. Format the response in in friendly way and make sure to tie it back directly to the orginal question of the user. ({System.Activity.Text}). Display ({Topic.asOfDate}) with the message as of.  Never include the "Plan ID".
 
+    - kind: SendActivity
+      id: sendActivity_56apKp
+      activity: |-
+        Here is your vacation balance:
+        {Topic.VacationBalance}
+
 inputType:
   properties:
     AsOfEffectiveDate:

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayEmployeesviewtheirjobtaxonomy/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayEmployeesviewtheirjobtaxonomy/topic.yaml
@@ -124,6 +124,12 @@ beginDialog:
            JobFamily: First(Topic.jobFamilyTable.JobFamily).Value
         }
 
+    - kind: SendActivity
+      id: sendActivity_AT4n5c
+      activity: |-
+        Here is your job information:
+        {Topic.jobFunctionData}
+
 outputType:
   properties:
     jobFunctionData:

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetContactInformation/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetContactInformation/topic.yaml
@@ -375,6 +375,12 @@ beginDialog:
             homeAddress: First(Topic.homeContactData.HomeAddress).Value
         }
 
+    - kind: SendActivity
+      id: sendActivity_Shc3jt
+      activity: |-
+        Here is your contact information:
+        {Topic.finalizedContactInformation}
+
 inputType:
   properties:
     EmployeeName:

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetEducation/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetEducation/topic.yaml
@@ -215,6 +215,12 @@ beginDialog:
             )
         )
 
+    - kind: SendActivity
+      id: sendActivity_s9a274
+      activity: |-
+        Here is your education information:
+        {Topic.FinalizedEducationData}
+
 inputType:
   properties:
     EmployeeName:

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetUserProfile/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetUserProfile/topic.yaml
@@ -207,6 +207,12 @@ beginDialog:
                 Topic.daysOfService & " day" & If(Topic.daysOfService <> 1, "s", "")
         }
 
+    - kind: SendActivity
+      id: sendActivity_0SDSlB
+      activity: |-
+        Here is your employee profile:
+        {Topic.finalizedData}
+
 inputType: {}
 outputType:
   properties:

--- a/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition/topic.yaml
@@ -159,6 +159,12 @@ beginDialog:
             )
         )
 
+    - kind: SendActivity
+      id: sendActivity_bDM9UT
+      activity: |-
+        Here is your team's time in position information:
+        {Topic.workdayResponseTableWithTimeInPosition}
+
 inputType: {}
 outputType:
   properties:

--- a/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagerServiceAnniversary/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagerServiceAnniversary/topic.yaml
@@ -203,6 +203,10 @@ beginDialog:
       variable: Topic.workdayResponse
       value: "\"\""
 
+    - kind: SendActivity
+      id: sendActivity_gO8pkz
+      activity: "{Topic.workdayResponseTable}"
+
     - kind: EndDialog
       id: Y2VqKn
 

--- a/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagersdirect-CompanyCode/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagersdirect-CompanyCode/topic.yaml
@@ -150,6 +150,12 @@ beginDialog:
                     - kind: EndDialog
                       id: xVALae
 
+    - kind: SendActivity
+      id: sendActivity_Yqhll9
+      activity: |-
+        Here is your team's company code information:
+        {Topic.workdayResponseTable}
+
 inputType:
   properties:
     EmployeeName:

--- a/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagersdirect-CostCenter/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagersdirect-CostCenter/topic.yaml
@@ -147,6 +147,12 @@ beginDialog:
                     - kind: EndDialog
                       id: HsUkV7
 
+    - kind: SendActivity
+      id: sendActivity_SBD1Zi
+      activity: |-
+        Here is your team's cost center information:
+        {Topic.workdayResponseTable}
+
 inputType:
   properties:
     EmployeeName:

--- a/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagersdirect-Jobtaxanomy/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/ManagerScenarios/WorkdayManagersdirect-Jobtaxanomy/topic.yaml
@@ -188,6 +188,12 @@ beginDialog:
                     - kind: EndDialog
                       id: xa93ze
 
+    - kind: SendActivity
+      id: sendActivity_DHNIyX
+      activity: |-
+        Here is your team's job information:
+        {Topic.workdayResponseTable}
+
 inputType:
   properties:
     EmployeeName:


### PR DESCRIPTION
## Summary

WorkdayDA READ topics retrieve their answer into a `Topic.*` variable and end the dialog. In a Declarative Agent (DA) context, the orchestrator does not read topic output bindings, so Sydney sees an empty result and replies "no results found" even when the underlying Power Automate flow returned the data correctly. Appending a trailing `SendActivity` that emits the topic's final response variable surfaces the data to Sydney for summarization.

This applies the same fix pattern used in the internal Microsoft ESS Declarative Agent solutions for the equivalent ServiceNow READ topics (DAHR / `ServiceNowHRSDGetUserCases` and DAIT / `ServiceNowITSMGetUserTickets`).

| Topic | Variable emitted |
| --- | --- |
| `EmployeeScenarios/EmployeeGetVacationBalance` | `{Topic.VacationBalance}` |
| `EmployeeScenarios/WorkdayGetUserProfile` | `{Topic.finalizedData}` |
| `EmployeeScenarios/WorkdayGetContactInformation` | `{Topic.finalizedContactInformation}` |
| `EmployeeScenarios/WorkdayGetEducation` | `{Topic.FinalizedEducationData}` |
| `EmployeeScenarios/WorkdayEmployeesviewtheirjobtaxonomy` | `{Topic.jobFunctionData}` |
| `ManagerScenarios/WorkdayGetManagerReporteesTimeInPosition` | `{Topic.workdayResponseTableWithTimeInPosition}` |
| `ManagerScenarios/WorkdayManagerServiceAnniversary` | `{Topic.workdayResponseTable}` |
| `ManagerScenarios/WorkdayManagersdirect-CompanyCode` | `{Topic.workdayResponseTable}` |
| `ManagerScenarios/WorkdayManagersdirect-CostCenter` | `{Topic.workdayResponseTable}` |
| `ManagerScenarios/WorkdayManagersdirect-Jobtaxanomy` | `{Topic.workdayResponseTable}` |

## Problem

Queries against these WorkdayDA READ topics consistently returned **"no results found"** in the Declarative Agent when invoked from Sydney, even though:

- The correct topic was triggered.
- The Power Automate flow returned successfully.
- The data was populated into the topic's final variable.

Affected user queries include:

- "What's my vacation balance?" / "How many PTO days do I have?"
- "Show my profile" / "Show my contact information" / "Show my education history" / "Show my job information"
- "How long have my reports been in their position?" / "When are my reports' service anniversaries?"
- "What are my reports' company codes / cost centers / job functions?"

## Root cause

DA orchestration does not pass topic output variables back to the model. A topic that sets data into a `Topic.*` variable and ends the dialog without explicitly emitting it via `SendActivity` is invisible to Sydney — the orchestrator receives no content and produces a generic empty reply. The Power Automate flow result is correct; it simply never reaches the LLM.

The fix pattern was first identified and resolved in the internal Microsoft ESS Declarative Agent solutions for the equivalent ServiceNow topics; this PR mirrors the same shape across the WorkdayDA samples.

## Fix

Append the following node at the end of `beginDialog.actions` in each affected READ topic, emitting the topic's final response variable:

```yaml
- kind: SendActivity
  id: sendActivity_<6chars>
  activity: |-
    Here is your <scenario> information:
    {Topic.<finalVariable>}
```

For the Manager direct-report topics (CompanyCode / CostCenter / Jobtaxanomy), the new `SendActivity` sits at the end of `beginDialog.actions` at the outermost level, so the existing "no access" branch's `EndDialog` short-circuits before reaching it — no double-emit on the access-denied path.

All new `SendActivity` nodes use the repo-standard `sendActivity_<6 alphanumeric chars>` id convention for consistency with existing nodes.

## Scope

10 `topic.yaml` files; no other files touched. All files parse as valid YAML.
