### PR TITLE
fix(workday-da): correct Education parser schema and add missing SendActivity to GovernmentIDs

### DIFF
--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetEducation/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetEducation/topic.yaml
@@ -1,4 +1,11 @@
 kind: AdaptiveDialog
+inputs:
+  - kind: AutomaticTaskInput
+    propertyName: EmployeeName
+    description: The name of the person whose employment data is being requested.
+    entity: PersonNamePrebuiltEntity
+    shouldPromptUser: false
+
 modelDescription: |-
   Use this topic when the user asks to VIEW or READ THEIR OWN education / academic history / schooling stored in Workday — degree (bachelor's, master's, MBA, PhD), diploma, certificate, school/university/college/institution, alma mater, major, field of study, minor, graduation year/date, GPA, academic qualifications, or credentials.
 
@@ -7,24 +14,17 @@ modelDescription: |-
   Data is retrieved from Workday and belongs exclusively to the requesting user.
 
   Do NOT trigger for general questions about tuition reimbursement, learning programs, or training
-inputs:
-  - kind: AutomaticTaskInput
-    propertyName: EmployeeName
-    description: The name of the person whose employment data is being requested.
-    entity: PersonNamePrebuiltEntity
-    shouldPromptUser: false
-
 beginDialog:
   kind: OnRecognizedIntent
   id: main
   intent:
     triggerQueries:
-      - Show my Education Details
-      - From which school I completed my BS degree Education?
-      - Show my Education Degrees
-      - What was my field of Study during Education?
-      - Show my First Year attended for BS degree Education?
-      - Show my Last Year attended for BS degree Education?
+      - "Show my Education Details "
+      - "From which school I completed my BS degree Education? "
+      - "Show my Education Degrees "
+      - "What was my field of Study during Education? "
+      - "Show my First Year attended for BS degree Education? "
+      - "Show my Last Year attended for BS degree Education? "
 
   actions:
     - kind: BeginDialog
@@ -42,7 +42,7 @@ beginDialog:
       input:
         binding:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
-          scenarioName: ="msdyn_HRWorkdayHCMEmployeeGetEducation"
+          scenarioName: msdyn_HRWorkdayHCMEmployeeGetEducation
 
       dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
@@ -70,13 +70,13 @@ beginDialog:
                         type:
                           kind: Record
                           properties:
-                      "@Descriptor": String
-                      ID:
-                        type:
-                          kind: Table
-                          properties:
-                            "@type": String
-                            "#text": String
+                            "@Descriptor": String
+                            ID:
+                              type:
+                                kind: Table
+                                properties:
+                                  "@type": String
+                                  "#text": String
 
                       Date_Degree_Received: String
                       Degree_Completed_Reference:
@@ -143,6 +143,10 @@ beginDialog:
                           kind: Table
                           properties:
                             "@type": String
+                            "#text": String
+
+      value: =Topic.workdayResponse
+
     - kind: BeginDialog
       id: M8G7as
       displayName: Refresh country name reference data
@@ -216,7 +220,7 @@ beginDialog:
         )
 
     - kind: SendActivity
-      id: sendActivity_s9a274
+      id: sendActivity_educationResponse
       activity: |-
         Here is your education information:
         {Topic.FinalizedEducationData}

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetGovernmentIDs/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetGovernmentIDs/topic.yaml
@@ -140,6 +140,12 @@ beginDialog:
             )
         )
 
+    - kind: SendActivity
+      id: sendActivity_uxFMLZ
+      activity: |-
+        Here is your government ID information:
+        {Topic.finalizedResponseTableData}
+
 inputType:
   properties:
     EmployeeName:


### PR DESCRIPTION
## Summary

Two related WorkdayDA topic fixes:

1. **`EmployeeScenarios/WorkdayGetEducation/topic.yaml`** — corrects three structural defects in the `ParseValue` schema that cause the topic to fail validation / parsing in Copilot Studio:
   - `Country_Reference.type.properties` had no body; `"@Descriptor"` and `ID` were dedented out and ended up as siblings of `Country_Reference` at the wrong tree level.
   - `Education_Reference.ID.type.properties` was missing `"#text": String` — every other identical `ID:` block in the same topic has it.
   - The `ParseValue` block was missing its required `value: =Topic.workdayResponse` field, so the parser had no input to consume.
   - Also aligns `scenarioName:` style with the dominant repo convention (bare literal instead of Power Fx `="..."` string formula).
2. **`EmployeeScenarios/WorkdayGetGovernmentIDs/topic.yaml`** — appends a trailing `SendActivity` emitting `{Topic.finalizedResponseTableData}` so the DA orchestrator surfaces the topic's response to Sydney. Same root cause and fix pattern as the ten READ topics landed in #522.

## Problem

### Education topic

The Education topic's `ParseValue` block did not match the structure the Workday Get Education flow returns. The mis-indented `Country_Reference` block left `@Descriptor` and `ID` at the wrong level inside `Education_Data.properties`, the truncated `Education_Reference.ID` block omitted `"#text"`, and the missing `value:` line meant no source variable was being parsed. The MCS topic-schema validator rejects the file in this state, and even if accepted at runtime the parsed record cannot be referenced correctly.

### GovernmentIDs topic

Same root cause as #522: DA orchestration does not pass topic output variables to the model, so the `Topic.finalizedResponseTableData` table populated by this topic is invisible to Sydney without an explicit `SendActivity` emitter. Result: "no government IDs found" replies even when the Power Automate flow returned the data correctly.