### PR TITLE
Fix WorkdayDA employee topics: remove redundant inputs, fix scenarioName, add empty response handling

### DIFF
--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetEducation/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetEducation/topic.yaml
@@ -1,11 +1,4 @@
 kind: AdaptiveDialog
-inputs:
-  - kind: AutomaticTaskInput
-    propertyName: EmployeeName
-    description: The name of the person whose employment data is being requested.
-    entity: PersonNamePrebuiltEntity
-    shouldPromptUser: false
-
 modelDescription: |-
   Use this topic when the user asks to VIEW or READ THEIR OWN education / academic history / schooling stored in Workday — degree (bachelor's, master's, MBA, PhD), diploma, certificate, school/university/college/institution, alma mater, major, field of study, minor, graduation year/date, GPA, academic qualifications, or credentials.
 
@@ -17,25 +10,8 @@ modelDescription: |-
 beginDialog:
   kind: OnRecognizedIntent
   id: main
-  intent:
-    triggerQueries:
-      - "Show my Education Details "
-      - "From which school I completed my BS degree Education? "
-      - "Show my Education Degrees "
-      - "What was my field of Study during Education? "
-      - "Show my First Year attended for BS degree Education? "
-      - "Show my Last Year attended for BS degree Education? "
-
+  intent: {}
   actions:
-    - kind: BeginDialog
-      id: zQU3vE
-      displayName: Check access
-      input:
-        binding:
-          EmployeeName: =Topic.EmployeeName
-
-      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemAccessCheck
-
     - kind: BeginDialog
       id: B7ae9T
       displayName: Redirect to Get CommonExecution
@@ -219,11 +195,22 @@ beginDialog:
             )
         )
 
-    - kind: SendActivity
-      id: sendActivity_educationResponse
-      activity: |-
-        Here is your education information:
-        {Topic.FinalizedEducationData}
+    - kind: ConditionGroup
+      id: conditionGroup_PLj70M
+      conditions:
+        - id: conditionItem_TCBTE7
+          condition: =IsBlank(Topic.parsedWorkdayResponse.EducationData)
+          actions:
+            - kind: SendActivity
+              id: sendActivity_jPX7sn
+              activity: There is no education information listed for you in the system. If this information should be included, you can update it directly in Workday or reach out to HR for assistance.
+
+      elseActions:
+        - kind: SendActivity
+          id: sendActivity_educationResponse
+          activity: |-
+            Here is your education information:
+            {Topic.FinalizedEducationData}
 
 inputType:
   properties:

--- a/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetGovernmentIDs/topic.yaml
+++ b/EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetGovernmentIDs/topic.yaml
@@ -5,42 +5,18 @@ modelDescription: |-
   Trigger on "my" government-ID queries: "What is my SSN / PAN / Aadhaar / NI number?", "What's my passport number?", "When does my visa / work permit expire?", "Show my driver's license on file", "What's my tax ID?", "What government IDs are on my Workday profile?", "What's my green card / PR status?".
 
   Do NOT trigger for general questions about ID applications, renewals, immigration law, or work authorization policy
-inputs:
-  - kind: AutomaticTaskInput
-    propertyName: EmployeeName
-    description: The name of the employee whose data is being requested.
-    entity: PersonNamePrebuiltEntity
-    shouldPromptUser: false
-    inputSettings:
-      repeatCount: 0
-
 beginDialog:
   kind: OnRecognizedIntent
   id: main
-  intent:
-    triggerQueries:
-      - What are my Government Ids?
-      - Which Government ids are available on my profile?
-      - Show my Government Ids?
-      - Show me [EmployeeName]'s government Ids
-
+  intent: {}
   actions:
-    - kind: BeginDialog
-      id: GlRaX3
-      displayName: Check user access
-      input:
-        binding:
-          EmployeeName: =Topic.EmployeeName
-
-      dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemAccessCheck
-
     - kind: BeginDialog
       id: 3bFDxH
       displayName: Redirect to Workday System Get Common Execution
       input:
         binding:
           parameters: ="{""params"":[{""key"":""{Employee_ID}"",""value"":""" & Global.ESS_UserContext_Employee_Id & """},{""key"":""{As_Of_Effective_Date}"",""value"":"""& Text(Today(), "yyyy-MM-dd") &"""}]}"
-          scenarioName: ="msdyn_HRWorkdayHCMEmployeeGetGovernmentIds"
+          scenarioName: msdyn_HRWorkdayHCMEmployeeGetGovernmentIds
 
       dialog: msdyn_copilotforemployeeselfservicedahr.topic.WorkdaySystemGetCommonExecution
       output:
@@ -140,11 +116,22 @@ beginDialog:
             )
         )
 
-    - kind: SendActivity
-      id: sendActivity_uxFMLZ
-      activity: |-
-        Here is your government ID information:
-        {Topic.finalizedResponseTableData}
+    - kind: ConditionGroup
+      id: conditionGroup_PLj70M
+      conditions:
+        - id: conditionItem_TCBTE7
+          condition: =IsBlank(Topic.parsedWorkdayResponse.GovernmentId)
+          actions:
+            - kind: SendActivity
+              id: sendActivity_jPX7sn
+              activity: There are no government IDs listed for you in the system. If this information should be included, you can update it directly in Workday or reach out to HR for assistance.
+
+      elseActions:
+        - kind: SendActivity
+          id: sendActivity_uxFMLZ
+          activity: |-
+            Here is your government ID information:
+            {Topic.finalizedResponseTableData}
 
 inputType:
   properties:


### PR DESCRIPTION
## Summary
This PR fixes the **WorkdayGetGovernmentIDs** and **WorkdayGetEducation** topics in the Employee Self-Service Agent (WorkdayDA).

## Changes

### WorkdayGetGovernmentIDs
- Removed unused EmployeeName input and trigger queries (self-service only)
- Removed redundant WorkdaySystemAccessCheck dialog call
- Fixed scenarioName binding — changed from Power Fx expression to plain string value
- Added empty response handling with user-friendly message

### WorkdayGetEducation
- Removed unused EmployeeName input and trigger queries (self-service only)
- Removed redundant WorkdaySystemAccessCheck dialog call
- Added empty response handling with user-friendly message

## Files Changed
- EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetGovernmentIDs/topic.yaml
- EmployeeSelfServiceAgent/WorkdayDA/EmployeeScenarios/WorkdayGetEducation/topic.yaml


## Validated in DA agent:

<img width="781" height="724" alt="image" src="https://github.com/user-attachments/assets/38244c5e-0cb3-4d4a-9c47-dd96b083bc4c" />


<img width="362" height="273" alt="image" src="https://github.com/user-attachments/assets/5dc31084-be67-4069-a02b-935978005595" />
